### PR TITLE
Fix sandbox

### DIFF
--- a/src/sandbox/vite.config.js
+++ b/src/sandbox/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import config from '../../../vite.config';
+import config from '../../vite.config.js';
 
 export default defineConfig({
   ...config,


### PR DESCRIPTION
Attempting to launch the sandbox caused an error due to the relative path of the root vite.config.js being incorrect.