### PR TITLE
fix(Storybook): fixes white flash

### DIFF
--- a/src/packages/solid/.storybook/main.ts
+++ b/src/packages/solid/.storybook/main.ts
@@ -17,13 +17,22 @@
 
 const config = {
   stories: ['../components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: [
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        backgrounds: false
+      }
+    },
+    '@storybook/addon-links',
+    '@storybook/addon-interactions'
+  ],
   framework: {
-    name: "@storybook/html-vite",
-    options: {},
+    name: '@storybook/html-vite',
+    options: {}
   },
   docs: {
     autodocs: 'tag'
-  },
+  }
 };
 export default config;

--- a/src/packages/solid/.storybook/main.ts
+++ b/src/packages/solid/.storybook/main.ts
@@ -21,7 +21,10 @@ const config = {
     {
       name: '@storybook/addon-essentials',
       options: {
-        backgrounds: false
+        backgrounds: false,
+        outline: false, // disable outline addon
+        measure: false, // disable measure addon
+        viewport: false // disable viewport addon
       }
     },
     '@storybook/addon-links',

--- a/src/packages/solid/.storybook/manager-head.html
+++ b/src/packages/solid/.storybook/manager-head.html
@@ -1,5 +1,8 @@
-<link rel="shortcut icon" href="../assets/images/favicon.png" />
 <!-- use for style elements in Storybook's UI -->
+
+<!-- Storybook recommended location for custom favicon  -->
+<link rel="shortcut icon" href="../assets/images/favicon.png" />
+
 <style>
   /* sets background for preview iframe (Story only) */
   #storybook-preview-iframe {

--- a/src/packages/solid/.storybook/manager-head.html
+++ b/src/packages/solid/.storybook/manager-head.html
@@ -1,1 +1,8 @@
 <link rel="shortcut icon" href="../assets/images/favicon.png" />
+<!-- use for style elements in Storybook's UI -->
+<style>
+  /* sets background for preview iframe (Story only) */
+  #storybook-preview-iframe {
+    background-color: #1b1c1d;
+  }
+</style>

--- a/src/packages/solid/.storybook/preview-head.html
+++ b/src/packages/solid/.storybook/preview-head.html
@@ -1,0 +1,23 @@
+<!-- use to style elements in Storybook Docs -->
+<style>
+  /* transition background Docs to Story */
+  /* transition background from Story to Doc */
+  .sb-preparing-docs,
+  .sb-preparing-story {
+    background-color: #1b1c1d;
+  }
+  /* NOTE: this class is set to background and not background-color */
+  .sb-previewBlock {
+    background: #1b1c1d;
+  }
+
+  /* hides the args table that shows briefly during transition from Story to Docs */
+  .sb-argstableBlock {
+    display: none;
+  }
+
+  /* loading icons only seen during load/transition from Story to Docs */
+  .sb-previewBlock_icon {
+    background-color: #1b1c1d;
+  }
+</style>

--- a/src/packages/solid/.storybook/preview.tsx
+++ b/src/packages/solid/.storybook/preview.tsx
@@ -44,10 +44,7 @@ const preview = {
     backgrounds: { default: 'dark' },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
-      matchers: {
-        color: /(background|color)$/i,
-        date: /Date$/
-      }
+      expanded: true
     },
     docs: {
       theme: themes.dark

--- a/src/packages/solid/components/Button/Button.tsx
+++ b/src/packages/solid/components/Button/Button.tsx
@@ -28,6 +28,7 @@ withPadding;
  */
 export interface ButtonProps extends ButtonStyleProps, IntrinsicNodeProps {
   children?: string;
+  /** Testing which overrides what */
   suffix?: {
     checkbox?: Partial<CheckboxProps>;
     icon?: Partial<IconProps>;
@@ -45,7 +46,7 @@ export interface ButtonStyleProps {
   borderRadius?: number;
 }
 
-const Button: Component<ButtonProps> = props => {
+const Button: Component<ButtonProps> = (props) => {
   return (
     <node
       use:withPadding={styles.Container.padding}


### PR DESCRIPTION
Prior to 6.5, we were able to set `appBG` in the custom Storybook Theme to set the background in the Preview iframe. This is no longer the case. There are possible fixes coming but have not seen them actually committed to a release yet. [See this pr](https://github.com/storybookjs/storybook/pull/24575)

The other known issue is a white flash when clicking from a Story to the Docs of that Story. This is related to some classes being displayed and not displayed during 'loading' of the pages. The CSS overrides added in this PR are to fix those issues until Storybook fixes them.

This PR makes a few updates to the Storybook configuration:

- Adds CCS style overrides for style overrides the known `appBG` and the loading issue styles when clicking between Stories and Docs
- Disables the following Storybook addons from the toolbar: Background, Measure, Outline and Viewport. We are not utilizing these and most of them have to do with DOM anyway.
