### PR TITLE
fix(Storybook) : fix white flash during loading transition

### DIFF
--- a/src/packages/solid/.storybook/customTheme.ts
+++ b/src/packages/solid/.storybook/customTheme.ts
@@ -2,6 +2,7 @@ import { create, themes } from '@storybook/theming/create';
 import brand from '../assets/images/lightningjs-icon.png';
 
 export default create({
+  ...themes.dark,
   base: 'dark',
   brandTitle: `Lightning SolidJS UI Components`,
   brandUrl: 'https://github.com/lightning-js/ui-components',

--- a/src/packages/solid/.storybook/main.ts
+++ b/src/packages/solid/.storybook/main.ts
@@ -17,13 +17,25 @@
 
 const config = {
   stories: ['../components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: [
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        backgrounds: false, // disable background addon
+        outline: false, // disable outline addon
+        measure: false, // disable measure addon
+        viewport: false // disable viewport addon
+      }
+    },
+    '@storybook/addon-links',
+    '@storybook/addon-interactions'
+  ],
   framework: {
-    name: "@storybook/html-vite",
-    options: {},
+    name: '@storybook/html-vite',
+    options: {}
   },
   docs: {
     autodocs: 'tag'
-  },
+  }
 };
 export default config;

--- a/src/packages/solid/.storybook/manager-head.html
+++ b/src/packages/solid/.storybook/manager-head.html
@@ -1,1 +1,7 @@
 <link rel="shortcut icon" href="../assets/images/favicon.png" />
+<style>
+  /* temporary solution for background issue not being recognized by appContentBG */
+  #storybook-preview-iframe {
+    background-color: transparent !important;
+  }
+</style>

--- a/src/packages/solid/.storybook/manager.ts
+++ b/src/packages/solid/.storybook/manager.ts
@@ -1,7 +1,7 @@
-import { addons, types } from '@storybook/manager-api';
+import { addons } from '@storybook/manager-api';
 import customTheme from './customTheme';
 
 addons.setConfig({
-  theme: customTheme, // setting Storybook theme
+  theme: customTheme, // setting Storybook custom theme
   enableShortcuts: false
 });

--- a/src/packages/solid/.storybook/preview-head.html
+++ b/src/packages/solid/.storybook/preview-head.html
@@ -1,0 +1,23 @@
+<!-- use to style elements in Storybook Docs -->
+<style>
+  /* transition background Docs to Story */
+  /* transition background from Story to Doc */
+  .sb-preparing-docs,
+  .sb-preparing-story {
+    background-color: #1b1c1d;
+  }
+  /* NOTE: this class is set to background and not background-color */
+  .sb-previewBlock {
+    background: #1b1c1d;
+  }
+
+  /* hides the args table that shows briefly during transition from Story to Docs */
+  .sb-argstableBlock {
+    display: none;
+  }
+
+  /* loading icons only seen during load/transition from Story to Docs */
+  .sb-previewBlock_icon {
+    background-color: #1b1c1d;
+  }
+</style>

--- a/src/packages/solid/.storybook/preview.tsx
+++ b/src/packages/solid/.storybook/preview.tsx
@@ -41,7 +41,7 @@ export const args = {
 
 const preview = {
   parameters: {
-    backgrounds: { default: 'dark' },
+    backgrounds: { disable: true },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {

--- a/src/packages/solid/.storybook/preview.tsx
+++ b/src/packages/solid/.storybook/preview.tsx
@@ -44,10 +44,7 @@ const preview = {
     backgrounds: { disable: true },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
-      matchers: {
-        color: /(background|color)$/i,
-        date: /Date$/
-      }
+     expanded: true
     },
     docs: {
       theme: themes.dark


### PR DESCRIPTION
## Description
Prior to 6.5, we were able to set appBG in the custom Storybook Theme to set the background in the Preview iframe. This is no longer the case. There are possible fixes coming but have not seen them actually committed to a release yet. [see this pr that has been merged into an alpha release]https://github.com/storybookjs/storybook/pull/24575

The other known issue is a white flash when clicking from a Story to the Docs of that Story. This is related to some classes being displayed and not displayed during 'loading' of the pages. The CSS overrides added in this PR are to fix those issues until Storybook fixes them.[See this similar issue for reference]( https://github.com/storybookjs/storybook/pull/24575
)
This PR makes a few updates to the Storybook styles configuration:

- Adds CCS style overrides for style overrides the known appBG and the loading issue styles when clicking between Stories and Docs

## References
[LUI-1200](https://ccp.sys.comcast.net/browse/LUI-1200)

### Testing
clone pr
go to multiple Components
click from the Story to the Docs and back. You should no longer see the white flash