### PR TITLE
fix: various fixes

### DIFF
--- a/src/packages/solid/components/Button/Button.tsx
+++ b/src/packages/solid/components/Button/Button.tsx
@@ -32,7 +32,6 @@ interface ButtonProps extends NodeProps {
 const Button: Component<ButtonProps> = props => {
   return (
     <View
-      debug
       {...props}
       style={props?.style?.Container ?? styles.Container}
       tone={props.tone ?? styles.tone}
@@ -49,7 +48,6 @@ const Button: Component<ButtonProps> = props => {
 const ButtonContainer: Component<ButtonProps> = props => {
   return (
     <View
-      debug
       {...props}
       style={props?.style?.Container ?? styles.Container}
       tone={props.tone ?? styles.tone}

--- a/src/packages/solid/components/Button/Button.tsx
+++ b/src/packages/solid/components/Button/Button.tsx
@@ -16,17 +16,19 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, Text, type NodeProps, type NodeStyles, type TextStyles } from '@lightningjs/solid';
+import { View, Text, type NodeProps } from '@lightningjs/solid';
 import type { Tone } from 'types';
-import styles from './Button.styles.js';
+import styles, { type ButtonStyle } from './Button.styles.js';
 
 interface ButtonProps extends NodeProps {
   children: string | string[];
   tone?: Tone;
-  style?: {
-    Container?: NodeStyles;
-    Text?: TextStyles;
-  };
+  style?: Omit<ButtonStyle, 'tone'>;
+}
+
+interface ButtonContainerProps extends NodeProps {
+  tone?: Tone;
+  style?: Omit<ButtonStyle, 'tone'>;
 }
 
 const Button: Component<ButtonProps> = props => {
@@ -45,7 +47,7 @@ const Button: Component<ButtonProps> = props => {
   );
 };
 
-const ButtonContainer: Component<ButtonProps> = props => {
+const ButtonContainer: Component<ButtonContainerProps> = props => {
   return (
     <View
       {...props}
@@ -57,4 +59,10 @@ const ButtonContainer: Component<ButtonProps> = props => {
   );
 };
 
-export { Button as default, ButtonContainer, styles as ButtonStyles, type ButtonProps };
+export {
+  Button as default,
+  ButtonContainer,
+  styles as ButtonStyles,
+  type ButtonProps,
+  type ButtonContainerProps
+};

--- a/src/packages/solid/components/Metadata/Metadata.styles.ts
+++ b/src/packages/solid/components/Metadata/Metadata.styles.ts
@@ -25,11 +25,14 @@ const styles = {
   },
   titleText: {
     ...theme.typography.headline3,
-    contain: 'both'
+    fontSize: 20,
+    contain: 'width',
+    maxLines: 1
   },
   descriptionText: {
     ...theme.typography.body2,
-    contain: 'both',
+    fontSize: 20,
+    contain: 'width',
     maxLines: 3
   },
   disabled: {

--- a/src/packages/solid/components/Metadata/Metadata.tsx
+++ b/src/packages/solid/components/Metadata/Metadata.tsx
@@ -37,18 +37,13 @@ export interface MetadataProps extends NodeStyles {
 }
 
 const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
-
   return (
     <View style={styles.container} {...props}>
       <Text width={props.width} style={styles.titleText}>
         {props.title}
       </Text>
       <Show when={props.description}>
-        <Text
-          width={props.width}
-          height={styles.descriptionText.lineHeight * (props.maxLines || styles.descriptionText.maxLines)}
-          style={styles.descriptionText}
-        >
+        <Text width={props.width} style={styles.descriptionText}>
           {props.description}
         </Text>
       </Show>

--- a/src/packages/solid/components/Tile/Tile.stories.tsx
+++ b/src/packages/solid/components/Tile/Tile.stories.tsx
@@ -70,7 +70,7 @@ export const MetadataInset: Story = {
               width={theme.spacer.lg * 5}
               height={theme.spacer.xxl + theme.spacer.md}
             />
-            <Metadata debug title="Title" description={lorum} maxLines={1} />
+            <Metadata {...args.metadata} />
           </>
         }
       />
@@ -116,7 +116,7 @@ export const MetadataStandard: Story = {
             height={theme.spacer.xxl + theme.spacer.md}
           />
         }
-        bottom={<Metadata title="Title" description={lorum} maxLines={1} />}
+        bottom={<Metadata {...args.metadata} />}
       />
     );
   },
@@ -153,7 +153,7 @@ export const TileBadgeLabelSwitch: Story = {
             height={theme.spacer.xxl + theme.spacer.md}
           />
         }
-        bottom={<Metadata title="Title" description={lorum} maxLines={1} />}
+        bottom={<Metadata {...args.metadata} />}
       />
     );
   },
@@ -189,7 +189,7 @@ export const TileLogoCheckBoxTop: Story = {
           />
         }
         topRight={<Checkbox />}
-        inset={<Metadata title="Title" description={lorum} maxLines={1} />}
+        inset={<Metadata {...args.metadata} />}
       />
     );
   },
@@ -227,7 +227,7 @@ export const TileProgressBarTop: Story = {
         topLeft={<ProgressBar progress={0.5} width={380} />}
         inset={
           <>
-            <Metadata description={lorum} maxLines={1} mountY={0.5} />
+            <Metadata {...args.metadata} />
             <View
               src={'../../assets/images/Xfinity-Provider-Logo-2x1.png'}
               width={theme.spacer.lg * 5}

--- a/src/packages/solid/components/Tile/Tile.tsx
+++ b/src/packages/solid/components/Tile/Tile.tsx
@@ -40,7 +40,6 @@ export interface TileProps extends IntrinsicNodeProps {
 
 const Tile: Component<TileProps> = (props: TileProps) => {
   const [isFocused, setIsFocused] = createSignal(false);
-
   return (
     <node
       use:withPadding={styles.Container.padding}
@@ -54,7 +53,6 @@ const Tile: Component<TileProps> = (props: TileProps) => {
         {...props.artwork}
         width={props.width || styles.Container.width}
         height={props.height || styles.Container.height}
-        alt="Solid logo"
       />
 
       <Show when={props.persistentMetadata || isFocused()}>

--- a/src/packages/solid/utils/index.ts
+++ b/src/packages/solid/utils/index.ts
@@ -1,3 +1,4 @@
 export { default as mapToneToStateHook } from './mapToneToStateHook.js';
 export { makeComponentStyles } from './getThemeStyles.js';
 export { withScrolling } from './withScrolling.js';
+export { useItemLayout } from './useItemLayout.js';

--- a/src/packages/solid/utils/useItemLayout.ts
+++ b/src/packages/solid/utils/useItemLayout.ts
@@ -1,0 +1,18 @@
+import theme from 'theme';
+
+// TODO theme may need to be a parameter
+export const useItemLayout = (itemLayout: {
+  upCount: number;
+  ratioX: number;
+  ratioY: number;
+}): { width: number; height: number } | Record<string, never> => {
+  if (itemLayout) {
+    const width =
+      (theme.layout.screenW - theme.layout.marginX * 2) / itemLayout.upCount - theme.layout.gutterX;
+
+    const height = (width / itemLayout.ratioX) * itemLayout.ratioY;
+
+    return { width, height };
+  }
+  return {};
+};


### PR DESCRIPTION
## Description

A handful of fixes I came across while integrating with solidly-mosaic

## Changes

- remove debuggers from Tile
- remove hard coded alt text from Tile.Artwork
- clean up the Tile stories
- add the useItemLayout utility
- update metadata to no longer render the title and description on top of each other in some instances

## Testing

Review the Tile stories and ensure everything renders as expected