### PR TITLE
fix(withScrolling): parentheses accurate in conditional

### DIFF
--- a/src/packages/solid/components/Column/Column.stories.tsx
+++ b/src/packages/solid/components/Column/Column.stories.tsx
@@ -78,3 +78,17 @@ export const AlwaysScroll = {
     y: 0
   }
 };
+
+export const NeverScroll = {
+  render: (args: JSX.IntrinsicAttributes & ColumnProps) => {
+    return <SolidColumn autofocus {...args} />;
+  },
+  args: {
+    children: buttons,
+    scrollType: 'neverScroll',
+    wrap: false,
+    width: 400,
+    height: 500,
+    y: 360
+  }
+};

--- a/src/packages/solid/utils/withScrolling.ts
+++ b/src/packages/solid/utils/withScrolling.ts
@@ -55,10 +55,10 @@ export function withScrolling(adjustment: number = 0) {
         // if the (absolute value of current position  + the size of the visual portion of the row) is less than (the last Item position + the last Item size), then the last item is not shown
         // if scrolling backwards and the position of the selected item is less that the absolute value of the current position, the selected item is not shown
       } else if (
-        (scrollType !== 'lazyScroll' &&
-          scrollType !== 'neverScroll' &&
-          Math.abs(currentVal) + windowVal < lastItem.position + lastItem.size) ||
-        newVal < Math.abs(currentVal)
+        scrollType !== 'lazyScroll' &&
+        scrollType !== 'neverScroll' &&
+        (Math.abs(currentVal) + windowVal < lastItem.position + lastItem.size ||
+          newVal < Math.abs(currentVal))
       ) {
         next = -newVal + adjustment;
       }


### PR DESCRIPTION
## Description

fixing parenthesis so neverScroll works

