### PR TITLE
fix: storybook build

### DIFF
--- a/src/packages/solid/components/Button/Button.stories.tsx
+++ b/src/packages/solid/components/Button/Button.stories.tsx
@@ -15,7 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Meta, StoryObj } from 'storybook-solidjs';
-import Button, { ButtonContainer, ButtonStyles } from './Button.jsx';
+import Button, { ButtonContainer } from './Button.jsx';
+import buttonStyles from './Button.styles.js';
 import { Text } from '@lightningjs/solid';
 import Icon from '../Icon/Icon.jsx';
 import Checkbox from '../Checkbox/Checkbox.jsx';
@@ -77,8 +78,8 @@ export const Basic: Story = {
   render: args => {
     return (
       <ButtonContainer {...args}>
-        <Icon tone={args.tone ?? ButtonStyles.tone} width={22} height={28} src={lightning} />
-        <Text tone={args.tone ?? ButtonStyles.tone} debug style={ButtonStyles.Text}>
+        <Icon tone={args.tone ?? buttonStyles.tone} width={22} height={28} src={lightning} />
+        <Text tone={args.tone ?? buttonStyles.tone} style={buttonStyles.Text}>
           Button
         </Text>
       </ButtonContainer>
@@ -94,10 +95,10 @@ export const WithCheckbox: Story = {
   render: args => {
     return (
       <ButtonContainer {...args}>
-        <Checkbox checked tone={args.tone ?? ButtonStyles.tone}>
-          <Icon tone={args.tone ?? ButtonStyles.tone} width={18} height={14} src={check} />
+        <Checkbox checked tone={args.tone ?? buttonStyles.tone}>
+          <Icon tone={args.tone ?? buttonStyles.tone} width={18} height={14} src={check} />
         </Checkbox>
-        <Text tone={args.tone ?? ButtonStyles.tone} style={ButtonStyles.Text}>
+        <Text tone={args.tone ?? buttonStyles.tone} style={buttonStyles.Text}>
           Button
         </Text>
       </ButtonContainer>
@@ -113,11 +114,11 @@ export const WithCheckboxRight: Story = {
   render: args => {
     return (
       <ButtonContainer {...args}>
-        <Text tone={args.tone ?? ButtonStyles.tone} style={ButtonStyles.Text}>
+        <Text tone={args.tone ?? buttonStyles.tone} style={buttonStyles.Text}>
           Button
         </Text>
-        <Checkbox tone={args.tone ?? ButtonStyles.tone} checked>
-          <Icon tone={args.tone ?? ButtonStyles.tone} width={18} height={14} src={check} />
+        <Checkbox tone={args.tone ?? buttonStyles.tone} checked>
+          <Icon tone={args.tone ?? buttonStyles.tone} width={18} height={14} src={check} />
         </Checkbox>
       </ButtonContainer>
     );

--- a/src/packages/solid/components/Button/Button.tsx
+++ b/src/packages/solid/components/Button/Button.tsx
@@ -18,17 +18,17 @@
 import { type Component } from 'solid-js';
 import { View, Text, type NodeProps } from '@lightningjs/solid';
 import type { Tone } from 'types';
-import styles, { type ButtonStyle } from './Button.styles.js';
+import styles, { type ButtonStyles } from './Button.styles.js';
 
 interface ButtonProps extends NodeProps {
   children: string | string[];
   tone?: Tone;
-  style?: Omit<ButtonStyle, 'tone'>;
+  style?: Omit<ButtonStyles, 'tone'>;
 }
 
 interface ButtonContainerProps extends NodeProps {
   tone?: Tone;
-  style?: Omit<ButtonStyle, 'tone'>;
+  style?: Omit<ButtonStyles, 'tone'>;
 }
 
 const Button: Component<ButtonProps> = props => {

--- a/src/packages/solid/components/Icon/Icon.tsx
+++ b/src/packages/solid/components/Icon/Icon.tsx
@@ -17,7 +17,8 @@
 
 import type { Component } from 'solid-js';
 import { View, type IntrinsicNodeProps } from '@lightningjs/solid';
-import styles from './Icon.styles.js';
+import styles, { type IconStyles } from './Icon.styles.js';
+import type { Tone } from 'types';
 
 export interface IconProps extends IntrinsicNodeProps {
   /**
@@ -38,18 +39,19 @@ export interface IconProps extends IntrinsicNodeProps {
    * path to image or inline SVG XML
    */
   src?: string;
+
+  style?: Partial<IconStyles>;
+
+  tone?: Tone;
 }
 
 const Icon: Component<IconProps> = props => {
   return (
     <View
       {...props}
-      tone={props.tone || styles.tone}
-      style={styles.Container}
-      {...{
-        ...styles.Container[props.tone || styles.tone],
-        ...props?.style?.Container
-      }}
+      style={props?.style?.Container ?? styles.Container}
+      tone={props.tone ?? styles.tone}
+      states={props.tone ?? styles.tone}
     />
   );
 };


### PR DESCRIPTION
## Description

This PR fixes a misnamed import in Button which causes the storybook build to fail. It also cleans up the Icon tones setup

## Testing

run the storybook build `pnpm run solid:build-storybook`
