### PR TITLE
fix(utils): update mapToneToStateHook `states` type to only be arrays of strings

### DIFF
--- a/src/packages/solid/utils/mapToneToStateHook.ts
+++ b/src/packages/solid/utils/mapToneToStateHook.ts
@@ -1,9 +1,9 @@
 import type { ElementNode } from '@lightningjs/solid';
 
 // TODO update states to use ElementNode['States'] when support is added
-export default (node: ElementNode, states: { string: boolean }[]) => {
+export default (node: ElementNode, states: string[]) => {
   const nextState = node.tone
-    ? states.map((state: string | { string: boolean }) => {
+    ? states.map((state: string) => {
         if (state === node.tone) {
           return state; // don't create tone-tone states
         } else {


### PR DESCRIPTION
## Description

This PR updates the states type in the mapToneToStateHook to only be an array of `string` instead of an array of either `string` or `{string: boolean}`

## Testing

TS error should no longer appear when assigning mapToneToStateHook to Config.stateMapperHook
