### PR TITLE
fix: add service account email to release workflow, stop double publishing storybook

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,6 +27,7 @@ jobs:
       - name: git env setup
         run: |
           git config --global user.name "GitHub Action Runner"
+          git config --global user.email "svc-xd-suite@cable.comcast.com"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git remote set-url origin https://${{secrets.GH_PAT}}@github.com/lightning-js/ui-components
 

--- a/.github/workflows/publish-solid-storybook.yml
+++ b/.github/workflows/publish-solid-storybook.yml
@@ -2,10 +2,6 @@
 name: Deploy Solid Storybook to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ['main']
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

This PR adds the service account email to the git global config in the runner so we can commit changes, and removes the `on publish main` config from the storybook publish workflow

## Testing

n/a
