### PR TITLE
fix: update componentConfig to use defaultTone instead of tone

### DIFF
--- a/src/packages/solid/components/Artwork/Artwork.styles.ts
+++ b/src/packages/solid/components/Artwork/Artwork.styles.ts
@@ -17,7 +17,7 @@
 
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -39,7 +39,8 @@ type ArtworkStyleProperties = Partial<{
 type ArtworkConfig = ComponentStyleConfig<ArtworkStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Artwork: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Artwork: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: ArtworkConfig = {
   themeKeys: {
@@ -63,7 +64,7 @@ const container: ArtworkConfig = {
 const Container = makeComponentStyles<ArtworkStyles['Container']>(container);
 
 const styles: ArtworkStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container
 };
 

--- a/src/packages/solid/components/Badge/Badge.styles.ts
+++ b/src/packages/solid/components/Badge/Badge.styles.ts
@@ -17,7 +17,7 @@
 
 import theme from 'theme';
 import { type NodeStyles } from '@lightningjs/solid';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -39,7 +39,8 @@ type BadgeStyleProperties = Partial<{
 type BadgeConfig = ComponentStyleConfig<BadgeStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Badge: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Badge: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: BadgeConfig = {
   themeKeys: {
@@ -122,7 +123,7 @@ const Icon = makeComponentStyles<BadgeStyles['Icon']>(icon);
 const Text = makeComponentStyles<BadgeStyles['Text']>(text);
 
 const styles: BadgeStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   Icon,
   Text

--- a/src/packages/solid/components/Button/Button.styles.ts
+++ b/src/packages/solid/components/Button/Button.styles.ts
@@ -17,7 +17,7 @@
 
 import type { TextStyles, NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -39,7 +39,8 @@ type ButtonStyleProperties = {
 type ButtonConfig = ComponentStyleConfig<ButtonStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Button: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Button: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: ButtonConfig = {
   themeKeys: {
@@ -118,7 +119,7 @@ const Container = makeComponentStyles<ButtonStyles['Container']>(container);
 const Text = makeComponentStyles<ButtonStyles['Text']>(text);
 
 const styles: ButtonStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   Text
 };

--- a/src/packages/solid/components/Checkbox/Checkbox.styles.ts
+++ b/src/packages/solid/components/Checkbox/Checkbox.styles.ts
@@ -17,15 +17,17 @@
 
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
-import type { IconConfig, IconStyle } from '../Icon/Icon.styles.js';
+import type { IconConfig, IconStyles } from '../Icon/Icon.styles.js';
 
-export interface CheckboxStyle {
+export interface CheckboxStyles {
   tone: Tone;
   Container: NodeStyleSet;
-  Icon: NodeStyleSet;
+  Icon: {
+    Container: NodeStyleSet;
+  };
 }
 
 export type CheckboxStyleProperties = {
@@ -37,7 +39,8 @@ export type CheckboxStyleProperties = {
 
 type CheckboxConfig = ComponentStyleConfig<CheckboxStyleProperties>;
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Checkbox: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Checkbox: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const strokeWidth = theme.stroke.sm;
 const size = theme.spacer.xxl;
@@ -135,10 +138,10 @@ const icon: IconConfig = {
   themeStyles
 };
 
-const Container = makeComponentStyles<CheckboxStyle['Container']>(container);
-const Icon = makeComponentStyles<IconStyle['Container']>(icon);
-const styles: CheckboxStyle = {
-  tone: tone,
+const Container = makeComponentStyles<CheckboxStyles['Container']>(container);
+const Icon = makeComponentStyles<IconStyles['Container']>(icon);
+const styles: CheckboxStyles = {
+  tone: defaultTone,
   Container,
   Icon: { Container: Icon }
 };

--- a/src/packages/solid/components/Checkbox/Checkbox.tsx
+++ b/src/packages/solid/components/Checkbox/Checkbox.tsx
@@ -17,7 +17,7 @@
 
 import type { Component } from 'solid-js';
 import { View, type NodeProps } from '@lightningjs/solid';
-import styles from './Checkbox.styles.js';
+import styles, { type CheckboxStyles } from './Checkbox.styles.js';
 
 export interface CheckboxProps extends NodeProps {
   /**
@@ -25,6 +25,8 @@ export interface CheckboxProps extends NodeProps {
    * Setting this to `true` will check the checkbox, and setting it to `false` will uncheck it.
    */
   checked?: boolean;
+
+  style?: Partial<CheckboxStyles>;
 }
 
 const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
@@ -35,9 +37,10 @@ const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
       tone={props.tone ?? styles.tone}
       style={[
         props.style?.Container,
-        props.style?.Container[props.tone || styles.tone],
+        props.style?.Container?.[props.tone || styles.tone],
         styles.Container,
-        styles.Container[props.tone || styles.tone]]}
+        styles.Container[props.tone || styles.tone]
+      ]}
       states={{
         checked: props.checked
       }}

--- a/src/packages/solid/components/Column/Column.styles.ts
+++ b/src/packages/solid/components/Column/Column.styles.ts
@@ -16,7 +16,7 @@
  */
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -35,7 +35,8 @@ type ColumnStyleProperties = {
 type ColumnConfig = ComponentStyleConfig<ColumnStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Column: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Column: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: ColumnConfig = {
   themeKeys: {
@@ -59,7 +60,7 @@ const container: ColumnConfig = {
 const Container = makeComponentStyles<ColumnStyles['Container']>(container);
 
 const styles: ColumnStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container
 };
 

--- a/src/packages/solid/components/Icon/Icon.styles.ts
+++ b/src/packages/solid/components/Icon/Icon.styles.ts
@@ -17,7 +17,7 @@
 
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -33,7 +33,8 @@ export type IconStyleProperties = {
 export type IconConfig = ComponentStyleConfig<IconStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Icon: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Icon: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: IconConfig = {
   themeKeys: {
@@ -58,7 +59,7 @@ const container: IconConfig = {
 const Container = makeComponentStyles<IconStyles['Container']>(container);
 
 const styles: IconStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container
 };
 

--- a/src/packages/solid/components/Key/Key.styles.ts
+++ b/src/packages/solid/components/Key/Key.styles.ts
@@ -16,7 +16,7 @@
  */
 import type { TextStyles, NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -51,7 +51,8 @@ export type KeyStyleProperties = {
 export type KeyConfig = ComponentStyleConfig<KeyStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Key: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Key: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: KeyConfig = {
   themeKeys: {
@@ -131,7 +132,7 @@ const Container = makeComponentStyles<KeyStyle['Container']>(container);
 const Text = makeComponentStyles<KeyStyle['Text']>(text);
 
 const styles: KeyStyle = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   Text
 };

--- a/src/packages/solid/components/Keyboard/Keyboard.styles.tsx
+++ b/src/packages/solid/components/Keyboard/Keyboard.styles.tsx
@@ -39,7 +39,8 @@ export type KeyboardStyleProperties = {
 type KeyboardConfig = ComponentStyleConfig<KeyboardStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Keyboard: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Keyboard: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: KeyboardConfig = {
   themeKeys: {
@@ -137,7 +138,7 @@ const Key = makeComponentStyles<KeyStyle['Container']>(key);
 const Text = makeComponentStyles<KeyboardStyle['Text']>(text);
 
 const styles: KeyboardStyle = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   Key: { Key },
   Text

--- a/src/packages/solid/components/Label/Label.styles.ts
+++ b/src/packages/solid/components/Label/Label.styles.ts
@@ -17,7 +17,7 @@
 
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -38,7 +38,8 @@ type LabelStyleProperties = Partial<{
 type LabelConfig = ComponentStyleConfig<LabelStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Label: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Label: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: LabelConfig = {
   themeKeys: {
@@ -92,7 +93,7 @@ const Container = makeComponentStyles<LabelStyles['Container']>(container);
 const Text = makeComponentStyles<LabelStyles['Container']>(text);
 
 const styles: LabelStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   Text
 };

--- a/src/packages/solid/components/ProgressBar/ProgressBar.styles.ts
+++ b/src/packages/solid/components/ProgressBar/ProgressBar.styles.ts
@@ -17,7 +17,7 @@
 
 import { type NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 
@@ -37,7 +37,7 @@ type ProgressBarStyleProperties = {
 type ProgressBarConfig = ComponentStyleConfig<ProgressBarStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { ProgressBar: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } =
+const { ProgressBar: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
   theme?.componentConfig;
 
 const container: ProgressBarConfig = {
@@ -82,7 +82,7 @@ const Container = makeComponentStyles<ProgressBarStyles['Container']>(container)
 const ProgressBar = makeComponentStyles<ProgressBarStyles['ProgressBar']>(progress);
 
 const styles: ProgressBarStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   ProgressBar
 };

--- a/src/packages/solid/components/Row/Row.styles.ts
+++ b/src/packages/solid/components/Row/Row.styles.ts
@@ -16,7 +16,7 @@
  */
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -35,7 +35,8 @@ type RowStyleProperties = {
 type RowConfig = ComponentStyleConfig<RowStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Row: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Row: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: RowConfig = {
   themeKeys: {
@@ -60,7 +61,7 @@ const container: RowConfig = {
 const Container = makeComponentStyles<RowStyles['Container']>(container);
 
 const styles: RowStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container
 };
 

--- a/src/packages/solid/components/Tile/Tile.styles.ts
+++ b/src/packages/solid/components/Tile/Tile.styles.ts
@@ -17,7 +17,7 @@
 
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
-import type { Tone } from 'types';
+import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
 
@@ -37,7 +37,8 @@ type TileStyleProperties = Partial<{
 type TileConfig = ComponentStyleConfig<TileStyleProperties>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Tile: { styles: tileThemeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Tile: { styles: tileThemeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
 const { Surface: { styles: surfaceThemeStyles } = { styles: {} } } = theme?.componentConfig;
 
@@ -105,7 +106,7 @@ const StandardBottom = makeComponentStyles<TileStyles['StandardBottom']>(standar
 const LogoContainer = makeComponentStyles<TileStyles['LogoContainer']>(logoContainer);
 
 const styles: TileStyles = {
-  tone: tone,
+  tone: defaultTone,
   Container,
   InsetBottom,
   StandardBottom,

--- a/src/packages/solid/templates/styles.template.ts
+++ b/src/packages/solid/templates/styles.template.ts
@@ -42,7 +42,8 @@ type ComponentConfig = ComponentStyleConfig<ComponentStyleProperties>;
 
 // replace Component with the component name, this line imports overrides from the theme's componentConfig if they exist
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
-const { Component: { styles: themeStyles, tone } = { styles: {}, tone: 'neutral' } } = theme?.componentConfig;
+const { Component: { styles: themeStyles, defaultTone } = { styles: {}, defaultTone: 'neutral' } } =
+  theme?.componentConfig;
 
 const container: ComponentConfig = {
   themeKeys: {


### PR DESCRIPTION
## Description

Updates the components to pull the default tone from the defaultTone componentConfig property instead of tone. also fixes some type issues in Checkbox

## Testing

ensure all components now reference defaultTone