### PR TITLE
fix(scrolling): addressing api changes and scrolling functionality - breaking

### DIFF
--- a/src/packages/solid/components/Column/Column.stories.tsx
+++ b/src/packages/solid/components/Column/Column.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
     },
     scroll: {
       control: { type: 'radio' },
-      options: ['auto', 'lazy', 'always', 'never'],
+      options: ['auto', 'lazy', 'always', 'none'],
       description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }
@@ -79,13 +79,13 @@ export const AlwaysScroll = {
   }
 };
 
-export const NeverScroll = {
+export const NoneScroll = {
   render: (args: JSX.IntrinsicAttributes & ColumnProps) => {
     return <SolidColumn autofocus {...args} />;
   },
   args: {
     children: buttons,
-    scroll: 'never',
+    scroll: 'none',
     wrap: false,
     width: 400,
     height: 500,

--- a/src/packages/solid/components/Column/Column.stories.tsx
+++ b/src/packages/solid/components/Column/Column.stories.tsx
@@ -38,10 +38,10 @@ const meta = {
         defaultValue: { summary: false }
       }
     },
-    lazyScroll: {
-      control: { type: 'boolean' },
-      description:
-        'if true, will only scroll the row if the item is off screen and `alwaysScroll` and `neverScroll` are both false.',
+    scroll: {
+      control: { type: 'radio' },
+      options: ['auto', 'lazy', 'always', 'never'],
+      description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }
       }
@@ -71,7 +71,7 @@ export const AlwaysScroll = {
   },
   args: {
     children: buttons,
-    scrollType: 'alwaysScroll',
+    scroll: 'always',
     wrap: false,
     width: 400,
     height: 500,
@@ -85,7 +85,7 @@ export const NeverScroll = {
   },
   args: {
     children: buttons,
-    scrollType: 'neverScroll',
+    scroll: 'never',
     wrap: false,
     width: 400,
     height: 500,

--- a/src/packages/solid/components/Column/Column.stories.tsx
+++ b/src/packages/solid/components/Column/Column.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
     },
     scroll: {
       control: { type: 'radio' },
-      options: ['auto', 'lazy', 'always', 'none'],
+      options: ['auto', 'edge', 'always', 'none'],
       description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -30,8 +30,8 @@ export interface ColumnProps extends NodeProps {
     auto- scroll until the last index is visible on the screen, then dont scroll
     lazy- only scrolling when the component going to is not on screen
     always- always scrolling
-    never- never scrolling */
-  scroll?: 'always' | 'never' | 'lazy' | 'auto';
+    none- none scrolling */
+  scroll?: 'always' | 'none' | 'lazy' | 'auto';
   selected?: number;
   onUp?: KeyHandler;
   onDown?: KeyHandler;
@@ -58,7 +58,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll === undefined || props.scroll !== 'never' ? withScrolling(props.y as number) : () => {}
+        props.scroll === undefined || props.scroll !== 'none' ? withScrolling(props.y as number) : () => {}
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -58,7 +58,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll === undefined || props.scroll !== 'none' ? withScrolling(props.y as number) : () => {}
+        props.scroll !== 'none' ? withScrolling(props.y as number) : () => {}
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -58,7 +58,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll !== 'none' ? withScrolling(props.y as number) : () => {}
+        props.scroll !== 'none' ? withScrolling(props.y as number) : undefined
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -24,9 +24,14 @@ import { handleNavigation, onGridFocus } from '../../utils/handleNavigation.js';
 import { chainFunctions } from '../../index.js';
 
 export interface ColumnProps extends NodeProps {
-  /** Item index at which scrolling begins */
+  /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
-  scrollType?: 'alwaysScroll' | 'neverScroll' | 'lazyScroll';
+  /* Determines when to scroll: 
+    auto- scroll until the last index is visible on the screen, then dont scroll
+    lazy- only scrolling when the component going to is not on screen
+    always- always scrolling
+    never- never scrolling */
+  scroll?: 'always' | 'never' | 'lazy' | 'auto';
   selected?: number;
   onUp?: KeyHandler;
   onDown?: KeyHandler;
@@ -51,7 +56,10 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       onDown={chainFunctions(props.onDown, onDown)}
       selected={props.selected || 0}
       forwardFocus={onGridFocus}
-      onSelectedChanged={chainFunctions(props.onSelectedChanged, withScrolling(props.y as number))}
+      onSelectedChanged={chainFunctions(
+        props.onSelectedChanged,
+        props.scroll === undefined || props.scroll !== 'never' ? withScrolling(props.y as number) : () => {}
+      )}
       style={[props.style, styles.Container]}
     />
   );

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -26,16 +26,27 @@ import { chainFunctions } from '../../index.js';
 export interface ColumnProps extends NodeProps {
   /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
-  /* Determines when to scroll: 
-    auto- scroll until the last index is visible on the screen, then dont scroll
-    lazy- only scrolling when the component going to is not on screen
-    always- always scrolling
-    none- none scrolling */
-  scroll?: 'always' | 'none' | 'lazy' | 'auto';
+  /** Determines when to scroll(shift items along the axis):
+   * auto - scroll items immediately
+   * edge - scroll items when focus reaches the last item on screen
+   * always - focus remains at index 0, scroll until the final item is at index 0
+   * none - disable scrolling behavior, focus shifts as expected
+   * in both `auto` and `edge` items will only scroll until the last item is on screen */
+  scroll?: 'always' | 'none' | 'edge' | 'auto';
+
+  /** The inital index */
   selected?: number;
-  onUp?: KeyHandler;
-  onDown?: KeyHandler;
+
+  /** function to be called on right click */
+  onRight?: KeyHandler;
+
+  /** function to be called on right click */
+  onLeft?: KeyHandler;
+
+  /** function to be called when component gets focus */
   onFocus?: KeyHandler;
+
+  /** function to be called when the selected of the component changes */
   onSelectedChanged?: (
     this: ElementNode,
     elm: ElementNode,

--- a/src/packages/solid/components/Row/Row.stories.tsx
+++ b/src/packages/solid/components/Row/Row.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     },
     scroll: {
       control: { type: 'radio' },
-      options: ['auto', 'lazy', 'always', 'never'],
+      options: ['auto', 'lazy', 'always', 'none'],
       description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }
@@ -97,7 +97,7 @@ export const AlwaysScroll = {
   }
 };
 
-export const NeverScroll = {
+export const NoneScroll = {
   render: args => {
     return (
       <SolidRow autofocus {...args}>
@@ -107,7 +107,7 @@ export const NeverScroll = {
   },
   args: {
     children: buttons,
-    scroll: 'never',
+    scroll: 'none',
     wrap: false,
     height: 500,
     width: 800,

--- a/src/packages/solid/components/Row/Row.stories.tsx
+++ b/src/packages/solid/components/Row/Row.stories.tsx
@@ -13,9 +13,9 @@ const meta = {
         defaultValue: { summary: '[]' }
       }
     },
-    scrollType: {
+    scroll: {
       control: { type: 'radio' },
-      options: ['lazyScroll', 'alwaysScroll', 'neverScroll'],
+      options: ['auto', 'lazy', 'always', 'never'],
       description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }
@@ -71,7 +71,7 @@ export const LazyScroll = {
   },
   args: {
     children: buttons,
-    scrollType: 'lazyScroll',
+    scroll: 'lazy',
     wrap: false,
     height: 500,
     width: 800,
@@ -89,7 +89,7 @@ export const AlwaysScroll = {
   },
   args: {
     children: buttons,
-    scrollType: 'alwaysScroll',
+    scroll: 'always',
     wrap: false,
     height: 500,
     width: 800,
@@ -107,7 +107,7 @@ export const NeverScroll = {
   },
   args: {
     children: buttons,
-    scrollType: 'neverScroll',
+    scroll: 'never',
     wrap: false,
     height: 500,
     width: 800,

--- a/src/packages/solid/components/Row/Row.stories.tsx
+++ b/src/packages/solid/components/Row/Row.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     },
     scroll: {
       control: { type: 'radio' },
-      options: ['auto', 'lazy', 'always', 'none'],
+      options: ['auto', 'edge', 'always', 'none'],
       description: 'determines when to scroll',
       table: {
         defaultValue: { summary: false }
@@ -61,7 +61,7 @@ export const Basic = {
   }
 };
 
-export const LazyScroll = {
+export const edgeScroll = {
   render: args => {
     return (
       <SolidRow autofocus {...args}>
@@ -71,7 +71,7 @@ export const LazyScroll = {
   },
   args: {
     children: buttons,
-    scroll: 'lazy',
+    scroll: 'edge',
     wrap: false,
     height: 500,
     width: 800,

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -24,9 +24,14 @@ import { withScrolling } from '../../utils/withScrolling.js';
 import { chainFunctions } from '../../index.js';
 
 export interface RowProps extends NodeProps {
-  /** Item index at which scrolling begins */
+  /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
-  scrollType?: 'alwaysScroll' | 'neverScroll' | 'lazyScroll';
+  /* Determines when to scroll: 
+    auto- scroll until the last index is visible on the screen, then dont scroll
+    lazy- only scrolling when the component going to is not on screen
+    always- always scrolling
+    never- never scrolling */
+  scroll?: 'always' | 'never' | 'lazy' | 'auto';
   selected?: number;
   onRight?: KeyHandler;
   onLeft?: KeyHandler;
@@ -51,7 +56,10 @@ const Row: Component<RowProps> = (props: RowProps) => {
       onLeft={chainFunctions(props.onLeft, onLeft)}
       onRight={chainFunctions(props.onRight, onRight)}
       forwardFocus={onGridFocus}
-      onSelectedChanged={chainFunctions(props.onSelectedChanged, withScrolling(props.x as number))}
+      onSelectedChanged={chainFunctions(
+        props.onSelectedChanged,
+        props.scroll === undefined || props.scroll !== 'never' ? withScrolling(props.x as number) : () => {}
+      )}
       style={[props.style, styles.Container]}
     />
   );

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -58,7 +58,7 @@ const Row: Component<RowProps> = (props: RowProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll === undefined || props.scroll !== 'none' ? withScrolling(props.x as number) : () => {}
+        props.scroll !== 'none' ? withScrolling(props.x as number) : () => {}
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -26,16 +26,28 @@ import { chainFunctions } from '../../index.js';
 export interface RowProps extends NodeProps {
   /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
-  /* Determines when to scroll: 
-    auto- scroll until the last index is visible on the screen, then dont scroll
-    lazy- only scrolling when the component going to is not on screen
-    always- always scrolling
-    none- none scrolling */
-  scroll?: 'always' | 'none' | 'lazy' | 'auto';
+
+  /** Determines when to scroll(shift items along the axis):
+   * auto - scroll items immediately
+   * edge - scroll items when focus reaches the last item on screen
+   * always - focus remains at index 0, scroll until the final item is at index 0
+   * none - disable scrolling behavior, focus shifts as expected
+   * in both `auto` and `edge` items will only scroll until the last item is on screen */
+  scroll?: 'always' | 'none' | 'edge' | 'auto';
+
+  /** The inital index */
   selected?: number;
+
+  /** function to be called on right click */
   onRight?: KeyHandler;
+
+  /** function to be called on right click */
   onLeft?: KeyHandler;
+
+  /** function to be called when component gets focus */
   onFocus?: KeyHandler;
+
+  /** function to be called when the selected of the component changes */
   onSelectedChanged?: (
     this: ElementNode,
     elm: ElementNode,

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -58,7 +58,7 @@ const Row: Component<RowProps> = (props: RowProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll !== 'none' ? withScrolling(props.x as number) : () => {}
+        props.scroll !== 'none' ? withScrolling(props.x as number) : undefined
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -30,8 +30,8 @@ export interface RowProps extends NodeProps {
     auto- scroll until the last index is visible on the screen, then dont scroll
     lazy- only scrolling when the component going to is not on screen
     always- always scrolling
-    never- never scrolling */
-  scroll?: 'always' | 'never' | 'lazy' | 'auto';
+    none- none scrolling */
+  scroll?: 'always' | 'none' | 'lazy' | 'auto';
   selected?: number;
   onRight?: KeyHandler;
   onLeft?: KeyHandler;
@@ -58,7 +58,7 @@ const Row: Component<RowProps> = (props: RowProps) => {
       forwardFocus={onGridFocus}
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
-        props.scroll === undefined || props.scroll !== 'never' ? withScrolling(props.x as number) : () => {}
+        props.scroll === undefined || props.scroll !== 'none' ? withScrolling(props.x as number) : () => {}
       )}
       style={[props.style, styles.Container]}
     />

--- a/src/packages/solid/package.json
+++ b/src/packages/solid/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@solidjs/router": "^0.10.10",
-    "@storybook/html": "^7.6.14",
-    "@storybook/html-vite": "^7.6.14",
-    "solid-js": "^1.8.14"
+    "@storybook/html": "^7.6.17",
+    "@storybook/html-vite": "^7.6.17",
+    "solid-js": "^1.8.15"
   },
   "peerDependencies": {
     "@lightningjs/renderer": "^0.7.1",
@@ -46,27 +46,27 @@
   },
   "devDependencies": {
     "@lightningjs/vite-plugin-import-chunk-url": "^0.3.0",
-    "@storybook/addon-essentials": "^7.6.14",
-    "@storybook/addon-interactions": "^7.6.14",
-    "@storybook/addon-links": "^7.6.14",
-    "@storybook/blocks": "^7.6.14",
-    "@storybook/builder-vite": "^7.6.14",
-    "@storybook/manager-api": "^7.6.14",
+    "@storybook/addon-essentials": "^7.6.17",
+    "@storybook/addon-interactions": "^7.6.17",
+    "@storybook/addon-links": "^7.6.17",
+    "@storybook/blocks": "^7.6.17",
+    "@storybook/builder-vite": "^7.6.17",
+    "@storybook/manager-api": "^7.6.17",
     "@storybook/testing-library": "^0.2.2",
-    "@storybook/theming": "^7.6.14",
-    "@vitest/browser": "^1.2.2",
+    "@storybook/theming": "^7.6.17",
+    "@vitest/browser": "^1.3.1",
     "jsdom": "^24.0.0",
     "playwright": "^1.41.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "storybook": "^7.6.14",
+    "storybook": "^7.6.17",
     "storybook-solidjs": "1.0.0-beta.2",
     "storybook-solidjs-vite": "1.0.0-beta.2",
     "typescript": "^5.3.3",
-    "vite": "^5.1.1",
+    "vite": "^5.1.3",
     "vite-bundle-visualizer": "^1.0.1",
     "vite-plugin-cross-origin-isolation": "^0.1.6",
-    "vite-plugin-solid": "^2.9.1",
-    "vitest": "^1.2.2"
+    "vite-plugin-solid": "^2.10.1",
+    "vitest": "^1.3.1"
   }
 }

--- a/src/packages/solid/utils/withScrolling.ts
+++ b/src/packages/solid/utils/withScrolling.ts
@@ -66,19 +66,19 @@ export function withScrolling(adjustment: number = 0) {
       }
 
       // if we want to scroll based to the -x value of the selected
-      // this will be the case for always, and lazy when we are scrolling negatively and the current positioning does not have the selected item shown
+      // this will be the case for always, and edge when we are scrolling negatively and the current positioning does not have the selected item shown
       // if direction is negative and absolute value of current position is higher than the position we want to be at, the selected Item is not shown
     } else if (
       scroll === 'always' ||
-      (scroll === 'lazy' && direct === 'negative' && Math.abs(currentVal) > newVal)
+      (scroll === 'edge' && direct === 'negative' && Math.abs(currentVal) > newVal)
     ) {
       next = -newVal + adjustment;
 
       // if we want to scroll based on the size of the selected item
-      // this will be the case for lazy when we are scrolling positively and the current positioning does not have the selected item shown
+      // this will be the case for edge when we are scrolling positively and the current positioning does not have the selected item shown
       // if direction is positive and (absolute value of current position + the size of the visual portion of the row) is less than (the position we want to be at + the size of the selected Item), the selected Item is not shown
     } else if (
-      scroll === 'lazy' &&
+      scroll === 'edge' &&
       direct === 'positive' &&
       Math.abs(currentVal) + windowVal < newVal + size
     ) {


### PR DESCRIPTION
## Description
- reworking scrolling to use 'auto' as default
- scrollIndex only used in 'auto', no other scrolling types
- changing names in api

## Changes

## Testing

- Check scrolling is accurate for row and column with all types of scrolling (`auto`, `lazy`, `always`, `never`).
- Check all api changes have been made in all places 
- `scrollType` now `scroll`
- `lazyScroll` now `lazy`
- `alwaysScroll` now `always`
- `neverScroll` now `none`
