### PR TITLE
fix: rename fontStyle to fontWeight

### DIFF
--- a/src/packages/l3-ui-theme-base/theme.js
+++ b/src/packages/l3-ui-theme-base/theme.js
@@ -209,7 +209,7 @@ export default {
       fontFamily: 'Arial',
       fontSize: 75,
       lineHeight: 85,
-      fontStyle: '500',
+      fontWeight: 500,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
     },
@@ -217,14 +217,14 @@ export default {
       fontFamily: 'Arial',
       fontSize: 50,
       lineHeight: 60,
-      fontStyle: '500',
+      fontWeight: 500,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
     },
     headline1: {
       fontFamily: 'Arial',
       fontSize: 35,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 48,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -232,7 +232,7 @@ export default {
     headline2: {
       fontFamily: 'Arial',
       fontSize: 30,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 40,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -240,7 +240,7 @@ export default {
     headline3: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 36,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -248,7 +248,7 @@ export default {
     body1: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontStyle: '300',
+      fontWeight: 300,
       lineHeight: 40,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -256,7 +256,7 @@ export default {
     body2: {
       fontFamily: 'Arial',
       fontSize: 22,
-      fontStyle: '300',
+      fontWeight: 300,
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -264,7 +264,7 @@ export default {
     body3: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontStyle: '300',
+      fontWeight: 300,
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -272,7 +272,7 @@ export default {
     button1: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -280,7 +280,7 @@ export default {
     button2: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -288,7 +288,7 @@ export default {
     callout1: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -296,7 +296,7 @@ export default {
     caption1: {
       fontFamily: 'Arial',
       fontSize: 15,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 24,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -304,7 +304,7 @@ export default {
     tag1: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontStyle: '500',
+      fontWeight: 500,
       lineHeight: 24,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -312,7 +312,7 @@ export default {
     footnote1: {
       fontFamily: 'Arial',
       fontSize: 22,
-      fontStyle: '300',
+      fontWeight: 300,
       lineHeight: 30,
       verticalAlign: 'middle',
       textBaseline: 'bottom'

--- a/src/shared/AppCoreExtensions.js
+++ b/src/shared/AppCoreExtensions.js
@@ -25,11 +25,21 @@ export default class AppCoreExtension extends CoreExtension {
     stage.fontManager.addFontFace(
       new SdfTrFontFace(
         'Arial',
-        {},
+        { weight: 500 },
         'msdf',
         stage,
         './fonts/ubuntu/Ubuntu-Bold.msdf.png',
         './fonts/ubuntu/Ubuntu-Bold.msdf.json'
+      )
+    );
+    stage.fontManager.addFontFace(
+      new SdfTrFontFace(
+        'Arial',
+        { weight: 300 },
+        'msdf',
+        stage,
+        './fonts/ubuntu/Ubuntu-Regular.msdf.png',
+        './fonts/ubuntu/Ubuntu-Regular.msdf.json'
       )
     );
   }


### PR DESCRIPTION
## Description

This PR updates the base theme to use `fontWeight: number;` instead of `fontStyle: string` to declare a text element's font weight.It also updates the shared AppCoreExtension to setup Arial 500 and Arial 300 as ubuntu bold and ubuntu regular, respectively.

## Testing

storybook should now render text as expected
