### PR TITLE
fix: add default position values to row column

### DIFF
--- a/src/packages/solid/components/Column/Column.styles.ts
+++ b/src/packages/solid/components/Column/Column.styles.ts
@@ -46,6 +46,7 @@ const container: ColumnConfig = {
     display: 'flex',
     justifyContent: 'flexStart',
     flexDirection: 'column',
+    y: 0,
     gap: theme.layout.gutterY,
     itemTransition: {
       ...theme.animation.standardEntrance,

--- a/src/packages/solid/components/Row/Row.styles.ts
+++ b/src/packages/solid/components/Row/Row.styles.ts
@@ -46,6 +46,7 @@ const container: RowConfig = {
     display: 'flex',
     justifyContent: 'flexStart',
     flexDirection: 'row',
+    x: 0,
     gap: theme.layout.gutterX,
     width: theme.layout.screenW,
     itemTransition: {


### PR DESCRIPTION
## Description

The function `withScrolling()`, used in Row and Column, accesses the component ref's `x` and `y` values. These values do not have a default value in the Row and Column components, which causes the scrolling to not work when an x/y value is not provided as a prop.

## Changes

- Added default values for x and y in the Row and Column components respectively

## Testing

1. Instantiate a Row or Column component with a defined width or height, do not provide x/y, set scroll to "auto" or "edge"
2. Populate it with enough items to make the scrolling happen
3. Check if the component is scrolling correctly
