### PR TITLE
fix(withScrolling): scrolls selected item to correct position on creation when selected > 0

### DIFF
--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -64,6 +64,7 @@ export interface ColumnProps extends NodeProps {
 const Column: Component<ColumnProps> = (props: ColumnProps) => {
   const onUp = handleNavigation('up');
   const onDown = handleNavigation('down');
+  let Container;
 
   return (
     <View
@@ -72,6 +73,15 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       onDown={chainFunctions(props.onDown, onDown)}
       selected={props.selected || 0}
       forwardFocus={onGridFocus}
+      onCreate={() =>
+        withScrolling(props.y as number).call(
+          Container,
+          Container,
+          Container.children[props.selected ?? 0] as ElementNode,
+          props.selected ?? 0,
+          undefined
+        )
+      }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
         props.scroll !== 'none' ? withScrolling(props.y as number) : undefined
@@ -81,6 +91,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
         styles.Container.tones[props.tone ?? styles.tone],
         styles.Container.base
       ]}
+      ref={Container}
     />
   );
 };

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component, onMount } from 'solid-js';
+import { type Component } from 'solid-js';
 import { View, ElementNode, type NodeProps } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
 import styles, { type RowStyles } from './Row.styles.js';

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component } from 'solid-js';
+import { type Component, onMount } from 'solid-js';
 import { View, ElementNode, type NodeProps } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
 import styles, { type RowStyles } from './Row.styles.js';
@@ -65,6 +65,7 @@ export interface RowProps extends NodeProps {
 const Row: Component<RowProps> = (props: RowProps) => {
   const onLeft = handleNavigation('left');
   const onRight = handleNavigation('right');
+  let Container;
 
   return (
     <View
@@ -73,6 +74,15 @@ const Row: Component<RowProps> = (props: RowProps) => {
       onLeft={chainFunctions(props.onLeft, onLeft)}
       onRight={chainFunctions(props.onRight, onRight)}
       forwardFocus={onGridFocus}
+      onCreate={() =>
+        withScrolling(props.x as number).call(
+          Container,
+          Container,
+          Container.children[props.selected ?? 0] as ElementNode,
+          props.selected ?? 0,
+          undefined
+        )
+      }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
         props.scroll !== 'none' ? withScrolling(props.x as number) : undefined
@@ -84,6 +94,7 @@ const Row: Component<RowProps> = (props: RowProps) => {
         styles.Container.base
       ]}
       states={props.tone ?? styles.tone}
+      ref={Container}
     />
   );
 };

--- a/src/packages/solid/utils/withScrolling.ts
+++ b/src/packages/solid/utils/withScrolling.ts
@@ -28,16 +28,17 @@ export function withScrolling(adjustment: number = 0) {
       return;
     }
 
+    const dimension = componentRef.flexDirection === 'row' ? 'width' : 'height';
+    const axis = componentRef.flexDirection === 'row' ? 'x' : 'y';
+
     const gap = componentRef.gap || 0;
     const scroll = componentRef.scroll || 'auto';
     const [lastItem, containerSize] = updateLastIndex(componentRef);
 
     // values based on row or column
-    let rootPosition = (componentRef.flexDirection === 'row' ? componentRef.x : componentRef.y) ?? 0;
-    const selectedPosition =
-      (componentRef.flexDirection === 'row' ? selectedElement.x : selectedElement.y) ?? 0;
-    const selectedSize =
-      (componentRef.flexDirection === 'row' ? selectedElement.width : selectedElement.height) ?? 0;
+    let rootPosition = componentRef[axis] ?? 0;
+    const selectedPosition = selectedElement[axis] ?? 0;
+    const selectedSize = selectedElement[dimension] ?? 0;
 
     // TODO, find better name
     const direct = lastSelected === undefined ? 'none' : selected > lastSelected ? 'positive' : 'negative';
@@ -87,7 +88,7 @@ export function withScrolling(adjustment: number = 0) {
       next = rootPosition - selectedSize - gap;
     }
 
-    // if inital load, edge scroll type, and we have a selected index we want to go to on start
+    // if initial load, edge scroll type, and we have a selected index we want to go to on start
     else if (scroll === 'edge' && direct === 'none') {
       let currentChildIndex = 0;
       let currentChild, currentChildSize;
@@ -96,17 +97,16 @@ export function withScrolling(adjustment: number = 0) {
         Math.abs(rootPosition) + containerSize < selectedPosition + selectedSize
       ) {
         currentChild = componentRef.children[currentChildIndex++];
-        currentChildSize =
-          (componentRef.flexDirection === 'row' ? currentChild.width : currentChild.height) ?? 0;
+        currentChildSize = currentChild[dimension] ?? 0;
         rootPosition -= currentChildSize + gap;
       }
       next = rootPosition;
     }
 
     // updating value if scrolling is needed
-    if (componentRef.flexDirection === 'row' && componentRef.x !== next) {
+    if (axis === 'x' && componentRef.x !== next) {
       componentRef.x = next;
-    } else if (componentRef.flexDirection === 'column' && componentRef.y !== next) {
+    } else if (axis === 'y' && componentRef.y !== next) {
       componentRef.y = next;
     }
   };


### PR DESCRIPTION
## Description

- ensures accurate x value positioning on load of rows and columns when scroll type is always or edge and selectedIndex > 0 on component creation.
- runs withScrolling `onCreate` in addition to `onSelectedChanged`
- sets fallback rootPosition to 0 if no y/x value in componentRef
- updates variables in withScrolling to better articulate what values they represent


## Testing

- In the `Column.stories.ts` file or the `Row.stories.ts` file,  add a selected value greater than 0 to the arguments of the story. Notice how the x and y position shift so that the focused item is shown on the screen in the desired location
- In the `Column.stories.ts` file or the `Row.stories.ts` file, remove the x or y in a story that uses auto or edge scroll, notice how scrolling now works appropriately
