### PR TITLE
draft: remove support for style property in favor of named style override properties

### DIFF
--- a/src/packages/solid/components/Badge/Badge.styles.ts
+++ b/src/packages/solid/components/Badge/Badge.styles.ts
@@ -28,10 +28,26 @@ export interface BadgeStyles {
   Text: TextStyleSet;
 }
 
-type BadgeStyleProperties = Partial<{
+export type BadgeStyleProperties = Partial<{
+  /**
+   * container background color
+   */
   backgroundColor: NodeStyles['color'];
+
+  /**
+   * text color
+   */
   textColor: NodeStyles['color'];
+
+  /**
+   * icon image color
+   */
   iconColor: NodeStyles['color'];
+
+  /**
+   * container padding
+   */
+  padding: number[];
   // TODO these aren't being used
   // strokeColor: NodeStyles['color'];
   // borderColor: NodeStyles['color'];

--- a/src/packages/solid/components/Badge/Badge.styles.ts
+++ b/src/packages/solid/components/Badge/Badge.styles.ts
@@ -32,8 +32,9 @@ type BadgeStyleProperties = Partial<{
   backgroundColor: NodeStyles['color'];
   textColor: NodeStyles['color'];
   iconColor: NodeStyles['color'];
-  strokeColor: NodeStyles['color']; // TODO do we use this?
-  borderColor: NodeStyles['color'];
+  // TODO these aren't being used
+  // strokeColor: NodeStyles['color'];
+  // borderColor: NodeStyles['color'];
 }>;
 
 type BadgeConfig = ComponentStyleConfig<BadgeStyleProperties>;

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -15,36 +15,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Component } from 'solid-js';
-import { Text, Show } from '@lightningjs/solid';
+import { Text, Show, type NodeStyles } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
 import Icon, { type IconProps } from '../Icon/Icon.jsx';
-import styles, { type BadgeStyles } from './Badge.styles.js';
+import styles from './Badge.styles.js';
 import type { Tone } from '../../types/types.js';
 withPadding; // Preserve the import.
 
 export type BadgeProps = {
+  // Functional Properties
+
   /**
    * Badge text
    */
   title: string;
+
   // TODO better handling for default prop values
   /**
    * side of the text where icon will appear on
    * defaults to left if value is either undefined or invalid
    */
   iconAlign?: string;
+
   /**
    * Object containing all properties supported in the [Icon component](?path=/docs/components-icon--icon)
    */
   icon?: Partial<IconProps>;
+
   /**
    * sets the component's color palette
    */
   tone?: Tone;
 
+  // Style properties
   padding?: number[];
 
-  style?: Partial<BadgeStyles>;
+  /**
+   * override the default/tone container background color
+   */
+  backgroundColor: NodeStyles['color'];
+
+  /**
+   * override the default/tone text color
+   */
+  textColor: NodeStyles['color'];
+
+  /**
+   * override the default/tone icon image color
+   */
+  iconColor: NodeStyles['color'];
 };
 
 const Badge: Component<BadgeProps> = (props: BadgeProps) => {
@@ -56,17 +75,25 @@ const Badge: Component<BadgeProps> = (props: BadgeProps) => {
         styles.Container.base.padding
       }
       {...props}
+      color={props.backgroundColor}
       style={[
-        ...[props.style].flat(), //
-        styles.Container.tones[props.tone || styles.tone],
+        styles.Container.tones[props.tone || styles.tone], //
         styles.Container.base
       ]}
       forwardStates
     >
       <Show when={Boolean(props.icon && props.iconAlign !== 'right')}>
-        <Icon {...props.icon} style={[styles.Icon.tones[props.tone ?? styles.tone], styles.Icon.base]} />
+        <Icon
+          {...props.icon}
+          color={props.iconColor}
+          style={[
+            styles.Icon.tones[props.tone ?? styles.tone], //
+            styles.Icon.base
+          ]}
+        />
       </Show>
       <Text
+        color={props.textColor}
         style={[styles.Text.tones[props.tone ?? styles.tone], styles.Text.base]}
         tone={props.tone || styles.tone}
       >
@@ -75,6 +102,7 @@ const Badge: Component<BadgeProps> = (props: BadgeProps) => {
       <Show when={Boolean(props.icon && props.iconAlign === 'right')}>
         <Icon
           {...props.icon}
+          color={props.iconColor}
           style={[
             styles.Icon.tones?.[props.tone ?? styles.tone], //
             styles.Icon.base

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -15,14 +15,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Component } from 'solid-js';
-import { Text, Show, type NodeStyles } from '@lightningjs/solid';
+import { Text, Show } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
 import Icon, { type IconProps } from '../Icon/Icon.jsx';
-import styles from './Badge.styles.js';
+import styles, { type BadgeStyleProperties } from './Badge.styles.js';
 import type { Tone } from '../../types/types.js';
 withPadding; // Preserve the import.
 
-export type BadgeProps = {
+export type BadgeProps = BadgeStyleProperties & {
   // Functional Properties
 
   /**
@@ -46,24 +46,6 @@ export type BadgeProps = {
    * sets the component's color palette
    */
   tone?: Tone;
-
-  // Style properties
-  padding?: number[];
-
-  /**
-   * override the default/tone container background color
-   */
-  backgroundColor: NodeStyles['color'];
-
-  /**
-   * override the default/tone text color
-   */
-  textColor: NodeStyles['color'];
-
-  /**
-   * override the default/tone icon image color
-   */
-  iconColor: NodeStyles['color'];
 };
 
 const Badge: Component<BadgeProps> = (props: BadgeProps) => {


### PR DESCRIPTION
## The Problem

As we've written more components and begun to test them in client applications, it's become clear that supporting `node.style` in our components isn't maintainable. This PR explores the removing support for the generic `style` property in favor of providing specific style properties that can override the styles that would also be provided by themes. I've updated the Badge as an example of how this would work, open to any feedback on this setup

## Changes

- removes the style property from `BadgeProps`
- removes all references to `props.style` in the component markup
- BadgeProps is updated to an intersection of BadgeProps and BadgeStyleProperties
- the styles defined in BadgeStyleProperties are explicitly mapped to the relevant property in the component
  - ex. `props.iconColor` is assigned to `Badge.Icon.color`

## Testing

- import the Badge into an application(or storybook), ensure the style properties work as expected
- ensure components render as expected in storybook
