### PR TITLE
fix(withScrolling): prevent app crashes when withScrolling element has no children

### DIFF
--- a/src/packages/solid/utils/withScrolling.ts
+++ b/src/packages/solid/utils/withScrolling.ts
@@ -37,8 +37,9 @@ export function withScrolling(adjustment: number = 0) {
 
     // values based on row or column
     let rootPosition = componentRef[axis] ?? 0;
-    const selectedPosition = selectedElement[axis] ?? 0;
-    const selectedSize = selectedElement[dimension] ?? 0;
+    // optional chain prevents app from breaking when scrollable element has no initially selected element
+    const selectedPosition = selectedElement?.[axis] ?? 0;
+    const selectedSize = selectedElement?.[dimension] ?? 0;
 
     // TODO, find better name
     const direct = lastSelected === undefined ? 'none' : selected > lastSelected ? 'positive' : 'negative';


### PR DESCRIPTION
## Description

This PR resolves a bug found in client apps where scrollable elements will crash if the `selectedElement` comes back undefined

## Changes

adds optional chains to selectedElement references so they'll fall back to 0 in cases where selectedElement is undefined

## Testing

ensure withScrolling doesn't crash when selectedElement is undefined
