### PR TITLE
feat(Badge): separates Badge and Badge Container

### DIFF
--- a/src/packages/solid/components/Badge/Badge.stories.tsx
+++ b/src/packages/solid/components/Badge/Badge.stories.tsx
@@ -14,7 +14,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import Badge from './Badge.jsx';
+
+import Icon from '../Icon/Icon.jsx';
+import Badge, { BadgeContainer } from './Badge.jsx';
+import { Text } from '@lightningjs/solid';
+import styles from './Badge.styles.js';
 const lightning = '/assets/images/ic_lightning_white_32.png';
 
 const meta = {
@@ -54,12 +58,27 @@ export default meta;
 
 export const Basic = {
   args: {
-    title: 'Badge Text',
-    iconAlign: 'left',
-    icon: {
-      width: 20,
-      height: 20,
-      src: lightning
-    }
+    title: 'Badge Text'
+  }
+};
+
+export const BadgeIcon = {
+  render: args => {
+    return (
+      <BadgeContainer {...args}>
+        <Icon
+          style={[styles.Icon.tones[args.tone ?? styles.tone], styles.Icon.base]}
+          tone={args.tone ?? styles.tone}
+          src={lightning}
+          width={25}
+          height={25}
+        />
+        <Text style={[styles.Text.tones[args.tone ?? styles.tone], styles.Text.base]}>Badge Text</Text>
+      </BadgeContainer>
+    );
+  },
+
+  args: {
+    title: 'Badge Text'
   }
 };

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -15,9 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Component } from 'solid-js';
-import { Text, Show } from '@lightningjs/solid';
+import { Text, type NodeProps } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
-import Icon, { type IconProps } from '../Icon/Icon.jsx';
 import styles, { type BadgeStyles } from './Badge.styles.js';
 import type { Tone } from '../../types/types.js';
 withPadding; // Preserve the import.
@@ -27,16 +26,6 @@ type BadgeProps = {
    * Badge text
    */
   title: string;
-  // TODO better handling for default prop values
-  /**
-   * side of the text where icon will appear on
-   * defaults to left if value is either undefined or invalid
-   */
-  iconAlign?: string;
-  /**
-   * Object containing all properties supported in the [Icon component](?path=/docs/components-icon--icon)
-   */
-  icon?: Partial<IconProps>;
   /**
    * sets the component's color palette
    */

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -37,35 +37,10 @@ type BadgeProps = {
 };
 
 interface BadgeContainerProps extends NodeProps {
+  padding?: number[];
   tone?: Tone;
   style?: Omit<BadgeStyles, 'tone' | 'Text'>;
 }
-
-const Badge: Component<BadgeProps> = (props: BadgeProps) => {
-  return (
-    <node
-      use:withPadding={
-        props.padding ??
-        styles.Container?.tones[props.tone ?? styles.tone]?.padding ??
-        styles.Container.base.padding
-      }
-      {...props}
-      style={[
-        ...[props.style].flat(), //
-        styles.Container.tones[props.tone || styles.tone],
-        styles.Container.base
-      ]}
-      forwardStates
-    >
-      <Text
-        style={[styles.Text.tones[props.tone ?? styles.tone], styles.Text.base]}
-        tone={props.tone || styles.tone}
-      >
-        {props.title}
-      </Text>
-    </node>
-  );
-};
 
 const BadgeContainer: Component<BadgeContainerProps> = props => {
   return (
@@ -83,6 +58,19 @@ const BadgeContainer: Component<BadgeContainerProps> = props => {
       ]}
       forwardStates
     />
+  );
+};
+
+const Badge: Component<BadgeProps> = (props: BadgeProps) => {
+  return (
+    <BadgeContainer padding={props.padding} tone={props.tone} style={props.style}>
+      <Text
+        style={[styles.Text.tones[props.tone ?? styles.tone], styles.Text.base]}
+        tone={props.tone || styles.tone}
+      >
+        {props.title}
+      </Text>
+    </BadgeContainer>
   );
 };
 

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -22,7 +22,7 @@ import styles, { type BadgeStyles } from './Badge.styles.js';
 import type { Tone } from '../../types/types.js';
 withPadding; // Preserve the import.
 
-export type BadgeProps = {
+type BadgeProps = {
   /**
    * Badge text
    */
@@ -47,6 +47,11 @@ export type BadgeProps = {
   style?: Partial<BadgeStyles>;
 };
 
+interface BadgeContainerProps extends NodeProps {
+  tone?: Tone;
+  style?: Omit<BadgeStyles, 'tone' | 'Text'>;
+}
+
 const Badge: Component<BadgeProps> = (props: BadgeProps) => {
   return (
     <node
@@ -63,26 +68,33 @@ const Badge: Component<BadgeProps> = (props: BadgeProps) => {
       ]}
       forwardStates
     >
-      <Show when={Boolean(props.icon && props.iconAlign !== 'right')}>
-        <Icon {...props.icon} style={[styles.Icon.tones[props.tone ?? styles.tone], styles.Icon.base]} />
-      </Show>
       <Text
         style={[styles.Text.tones[props.tone ?? styles.tone], styles.Text.base]}
         tone={props.tone || styles.tone}
       >
         {props.title}
       </Text>
-      <Show when={Boolean(props.icon && props.iconAlign === 'right')}>
-        <Icon
-          {...props.icon}
-          style={[
-            styles.Icon.tones?.[props.tone ?? styles.tone], //
-            styles.Icon.base
-          ]}
-        />
-      </Show>
     </node>
   );
 };
 
-export default Badge;
+const BadgeContainer: Component<BadgeContainerProps> = props => {
+  return (
+    <node
+      use:withPadding={
+        props.padding ??
+        styles.Container?.tones[props.tone ?? styles.tone]?.padding ??
+        styles.Container.base.padding
+      }
+      {...props}
+      style={[
+        ...[props.style].flat(), //
+        styles.Container.tones[props.tone || styles.tone],
+        styles.Container.base
+      ]}
+      forwardStates
+    />
+  );
+};
+
+export { Badge as default, BadgeContainer, type BadgeProps, type BadgeContainerProps };


### PR DESCRIPTION
## Description

Creates a `badgeContainer` component that can take any number of children.
Allows `badge` to only take a title and hold text

## Changes

- removes all icon related properties from the Badge props
- adds badgeContainer component

## Testing

- check `Badge` and `BadgeContainer` and make sure everything works as expected
