### PR TITLE
fix: chainFunctions typescript

### DIFF
--- a/src/packages/solid/utils/chainFunctions.ts
+++ b/src/packages/solid/utils/chainFunctions.ts
@@ -15,7 +15,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable @typescript-eslint/ban-types */
 // take an array of functions and if you return true from a function, it will stop the chain
 export function chainFunctions<T>(...args: T[]) {
   const onlyFunctions = args.filter(func => typeof func === 'function');

--- a/src/packages/solid/utils/chainFunctions.ts
+++ b/src/packages/solid/utils/chainFunctions.ts
@@ -17,8 +17,8 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 // take an array of functions and if you return true from a function, it will stop the chain
-export const chainFunctions = (...args: (Function | undefined)[]) => {
-  const onlyFunctions = args.filter(func => typeof func === 'function') as Function[];
+export function chainFunctions<T>(...args: T[]) {
+  const onlyFunctions = args.filter(func => typeof func === 'function');
   if (onlyFunctions.length === 0) {
     return undefined;
   }
@@ -27,7 +27,7 @@ export const chainFunctions = (...args: (Function | undefined)[]) => {
     return onlyFunctions[0];
   }
 
-  return function (...innerArgs: unknown[]) {
+  return function (this: unknown, ...innerArgs: unknown[]) {
     let result;
     for (const func of onlyFunctions) {
       result = func.apply(this, innerArgs);
@@ -37,4 +37,4 @@ export const chainFunctions = (...args: (Function | undefined)[]) => {
     }
     return result;
   };
-};
+}


### PR DESCRIPTION
## Description

This pr removes the ts error reported with the Function type

![image](https://github.com/lightning-js/ui-components/assets/33352553/232b540c-af12-49b0-a6a6-66067e37af98)

## Changes

banned type Function replaced with < T >
