### PR TITLE
fix: normalize styles

### DIFF
--- a/src/packages/solid/components/Artwork/Artwork.tsx
+++ b/src/packages/solid/components/Artwork/Artwork.tsx
@@ -1,23 +1,26 @@
 import { type Component, createMemo } from 'solid-js';
-import { View, type IntrinsicNodeProps } from '@lightningjs/solid';
-import styles, { type ArtworkStyles } from './Artwork.styles.js';
+import { View, type Effects, type NodeProps } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
-import type { Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Artwork.styles.js';
 withPadding;
 
-export interface ArtworkProps extends ArtworkStyleProps, IntrinsicNodeProps {
+export interface ArtworkProps extends UIComponentProps {
   /**
    * Handles any blur/gradient/shader effects
    */
-  effects?: object;
+  effects?: Effects;
+
   /**
    * Sets the fallback image that will be shown in if the src request fails
    */
-  fallbackSrc?: string;
+  fallbackSrc?: NodeProps['src'];
+
   /**
    * Which image will be displayed
    */
-  src: string; // Inherited from lng.Element
+  src: NodeProps['src'];
+
   /**
    * optional callback that can be used to generate custom strings to request an image. The callback will be passed an object containing the following parameters: aspectRatio, src, w, h. Be default aspect ratio will match the closest value from srcCallbackAspectRatios
    */
@@ -28,9 +31,6 @@ export interface ArtworkProps extends ArtworkStyleProps, IntrinsicNodeProps {
     width: number;
     height: number;
   }) => string;
-
-  tone?: Tone;
-  style?: Omit<ArtworkStyles, 'tone'>;
 }
 
 export interface ArtworkStyleProps {}
@@ -44,8 +44,8 @@ const formatArtwork = (props: ArtworkProps) => {
       closestAspectRatio: undefined,
       aspectRatio: undefined,
       src: src,
-      width: props.width,
-      height: props.height
+      width: Number(props.width),
+      height: Number(props.height)
     });
   }
   return src;
@@ -66,7 +66,7 @@ const Artwork: Component<ArtworkProps> = props => {
             styles.Container.base.fillColor
       }
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/components/Badge/Badge.tsx
+++ b/src/packages/solid/components/Badge/Badge.tsx
@@ -15,31 +15,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Component } from 'solid-js';
-import { Text, type NodeProps } from '@lightningjs/solid';
+import { Text, type TextProps } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
-import styles, { type BadgeStyles } from './Badge.styles.js';
-import type { Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Badge.styles.js';
 withPadding; // Preserve the import.
 
-type BadgeProps = {
+interface BadgeProps extends UIComponentProps {
   /**
    * Badge text
    */
-  title: string;
-  /**
-   * sets the component's color palette
-   */
-  tone?: Tone;
+  title: TextProps['children'];
 
   padding?: number[];
+}
 
-  style?: Partial<BadgeStyles>;
-};
-
-interface BadgeContainerProps extends NodeProps {
+interface BadgeContainerProps extends UIComponentProps {
   padding?: number[];
-  tone?: Tone;
-  style?: Omit<BadgeStyles, 'tone' | 'Text'>;
 }
 
 const BadgeContainer: Component<BadgeContainerProps> = props => {
@@ -52,7 +44,7 @@ const BadgeContainer: Component<BadgeContainerProps> = props => {
       }
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/components/Button/Button.stories.tsx
+++ b/src/packages/solid/components/Button/Button.stories.tsx
@@ -93,7 +93,7 @@ export const Container: Story = {
           width={22}
           height={28}
           src={lightning}
-          style={[buttonStyles.Content.tones[args.tone ?? buttonStyles.tone], buttonStyles.Content]}
+          style={[buttonStyles.Content.tones[args.tone ?? buttonStyles.tone], buttonStyles.Content.base]}
         />
         <Text style={[buttonStyles.Text.tones[args.tone ?? buttonStyles.tone], buttonStyles.Text.base]}>
           Button

--- a/src/packages/solid/components/Button/Button.tsx
+++ b/src/packages/solid/components/Button/Button.tsx
@@ -16,19 +16,16 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, Text, type NodeProps } from '@lightningjs/solid';
-import type { Tone } from '../../types/types.js';
-import styles, { type ButtonStyles } from './Button.styles.js';
+import { View, Text, type NodeProps, type TextProps } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Button.styles.js';
 
-interface ButtonProps extends NodeProps {
-  children: string | string[];
-  tone?: Tone;
-  style?: Omit<ButtonStyles, 'tone'>;
+interface ButtonProps extends UIComponentProps {
+  children: TextProps['children'];
 }
 
-interface ButtonContainerProps extends NodeProps {
-  tone?: Tone;
-  style?: Omit<ButtonStyles, 'tone' | 'Text'>;
+interface ButtonContainerProps extends UIComponentProps {
+  children: NodeProps['children'];
 }
 
 const Button: Component<ButtonProps> = props => {
@@ -36,7 +33,7 @@ const Button: Component<ButtonProps> = props => {
     <View
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones?.[props.tone ?? styles.tone],
         styles.Container.base
       ]}
@@ -44,8 +41,7 @@ const Button: Component<ButtonProps> = props => {
     >
       <Text
         style={[
-          ...[props.style?.Text].flat(), //
-          styles.Text.tones[props.tone ?? styles.tone],
+          styles.Text.tones[props.tone ?? styles.tone], //
           styles.Text.base
         ]}
       >
@@ -60,7 +56,7 @@ const ButtonContainer: Component<ButtonContainerProps> = props => {
     <View
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones?.[props.tone ?? styles.tone],
         styles.Container.base
       ]}
@@ -69,4 +65,4 @@ const ButtonContainer: Component<ButtonContainerProps> = props => {
   );
 };
 
-export { Button as default, ButtonContainer, type ButtonProps, type ButtonContainerProps };
+export { Button as default, ButtonContainer, type ButtonProps };

--- a/src/packages/solid/components/Checkbox/Checkbox.tsx
+++ b/src/packages/solid/components/Checkbox/Checkbox.tsx
@@ -17,19 +17,18 @@
 
 import type { Component } from 'solid-js';
 import { View, type NodeProps } from '@lightningjs/solid';
-import styles, { type CheckboxStyles } from './Checkbox.styles.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Checkbox.styles.js';
 import Icon from '../Icon/Icon.jsx';
-import type { Tone } from '../../types/types.js';
 const check = '/assets/images/check-icon.png';
 
-export interface CheckboxProps extends NodeProps {
+export interface CheckboxProps extends UIComponentProps {
   /**
    * Indicates whether the checkbox is checked or unchecked.
    * Setting this to `true` will check the checkbox, and setting it to `false` will uncheck it.
    */
   checked?: boolean;
-  tone?: Tone;
-  style?: Partial<CheckboxStyles> | Partial<CheckboxStyles>[];
+  children?: NodeProps['children'];
 }
 
 const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
@@ -38,7 +37,7 @@ const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
       forwardStates
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones[props.tone ?? styles.tone],
         styles.Container.base
       ]}
@@ -49,8 +48,7 @@ const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
               <Icon
                 src={check}
                 style={[
-                  ...[props.style?.Icon].flat(), //
-                  styles.Icon.tones[props.tone || styles.tone],
+                  styles.Icon.tones[props.tone || styles.tone], //
                   styles.Icon.base
                 ]}
               />

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -16,7 +16,7 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, type ElementNode } from '@lightningjs/solid';
+import { View, type ElementNode, type IntrinsicNodeCommonProps } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
 import type { UIComponentProps } from '../../types/interfaces.js';
 import { handleNavigation, onGridFocus } from '../../utils/handleNavigation.js';
@@ -25,7 +25,8 @@ import { chainFunctions } from '../../utils/chainFunctions.js';
 import styles from './Column.styles.js';
 
 export interface ColumnProps extends UIComponentProps {
-  onCreate?: () => void;
+  /** function run on component mount */
+  onCreate?: IntrinsicNodeCommonProps['onCreate'];
   /** function to be called on down click */
   onDown?: KeyHandler;
 
@@ -73,8 +74,8 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       onDown={chainFunctions(props.onDown, onDown)}
       selected={props.selected || 0}
       forwardFocus={onGridFocus}
-      onCreate={chainFunctions(
-        elm =>
+      onCreate={chainFunctions<ColumnProps['onCreate']>(
+        (elm: ScrollableElementNode) =>
           withScrolling(props.y as number).call(
             elm,
             elm,

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -64,10 +64,13 @@ export interface ColumnProps extends NodeProps {
 const Column: Component<ColumnProps> = (props: ColumnProps) => {
   const onUp = handleNavigation('up');
   const onDown = handleNavigation('down');
+  let Container: ScrollableElementNode;
 
   return (
     <View
       {...props}
+      // @ts-expect-error this is fine
+      ref={Container}
       onUp={chainFunctions(props.onUp, onUp)}
       onDown={chainFunctions(props.onDown, onDown)}
       selected={props.selected || 0}

--- a/src/packages/solid/components/Column/Column.tsx
+++ b/src/packages/solid/components/Column/Column.tsx
@@ -16,17 +16,34 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, ElementNode, type NodeProps } from '@lightningjs/solid';
+import { View, type ElementNode } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
-import styles, { type ColumnStyles } from './Column.styles.js';
-import { withScrolling } from '../../utils/withScrolling.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import { handleNavigation, onGridFocus } from '../../utils/handleNavigation.js';
-import { chainFunctions } from '../../index.js';
-import type { Tone } from '../../types/types.js';
+import { withScrolling, type ScrollableElementNode } from '../../utils/withScrolling.js';
+import { chainFunctions } from '../../utils/chainFunctions.js';
+import styles from './Column.styles.js';
 
-export interface ColumnProps extends NodeProps {
-  /** When auto scrolling, item index at which scrolling begins */
-  scrollIndex?: number;
+export interface ColumnProps extends UIComponentProps {
+  onCreate?: () => void;
+  /** function to be called on down click */
+  onDown?: KeyHandler;
+
+  /** function to be called when component gets focus */
+  onFocus?: KeyHandler;
+
+  /** function to be called on up click */
+  onUp?: KeyHandler;
+
+  /** function to be called when the selected of the component changes */
+  onSelectedChanged?: (
+    this: ScrollableElementNode,
+    elm: ScrollableElementNode,
+    active: ElementNode,
+    selectedIndex: number,
+    lastSelectedIndex: number
+  ) => void;
+
   /** Determines when to scroll(shift items along the axis):
    * auto - scroll items immediately
    * edge - scroll items when focus reaches the last item on screen
@@ -35,30 +52,11 @@ export interface ColumnProps extends NodeProps {
    * in both `auto` and `edge` items will only scroll until the last item is on screen */
   scroll?: 'always' | 'none' | 'edge' | 'auto';
 
-  /** The inital index */
+  /** When auto scrolling, item index at which scrolling begins */
+  scrollIndex?: number;
+
+  /** The initial index */
   selected?: number;
-
-  /** function to be called on up click */
-  onUp?: KeyHandler;
-
-  /** function to be called on down click */
-  onDown?: KeyHandler;
-
-  /** function to be called when component gets focus */
-  onFocus?: KeyHandler;
-
-  /** function to be called when the selected of the component changes */
-  onSelectedChanged?: (
-    this: ElementNode,
-    elm: ElementNode,
-    active: ElementNode,
-    selectedIndex: number,
-    lastSelectedIndex: number
-  ) => void;
-
-  tone?: Tone;
-
-  style?: Partial<ColumnStyles>;
 }
 
 const Column: Component<ColumnProps> = (props: ColumnProps) => {
@@ -91,7 +89,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
         props.scroll !== 'none' ? withScrolling(props.y as number) : undefined
       )}
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone ?? styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/components/Icon/Icon.tsx
+++ b/src/packages/solid/components/Icon/Icon.tsx
@@ -17,32 +17,29 @@
 
 import { type Component } from 'solid-js';
 import { View, type IntrinsicNodeProps } from '@lightningjs/solid';
-import styles, { type IconStyles } from './Icon.styles.js';
-import type { Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Icon.styles.js';
 
-export interface IconProps extends IntrinsicNodeProps {
+export interface IconProps extends UIComponentProps {
   /**
    * icon color (can only be applied on png icons)
    */
-  color?: number;
-  /**
-   * icon width
-   */
-  width?: number;
+  color?: UIComponentProps['color'];
 
   /**
    * icon height
    */
-  height?: number;
+  height?: IntrinsicNodeProps['height'];
 
   /**
    * path to image or inline SVG XML
    */
-  src?: string;
+  src?: IntrinsicNodeProps['src'];
 
-  style?: Partial<IconStyles>;
-
-  tone?: Tone;
+  /**
+   * icon width
+   */
+  width?: IntrinsicNodeProps['width'];
 }
 
 const Icon: Component<IconProps> = props => {
@@ -50,7 +47,7 @@ const Icon: Component<IconProps> = props => {
     <View
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones?.[props.tone || styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/components/Input/Input.tsx
+++ b/src/packages/solid/components/Input/Input.tsx
@@ -16,11 +16,11 @@
  */
 
 import { createSignal, type Component, type Signal, createEffect, on } from 'solid-js';
-import { View, Text, type IntrinsicNodeProps } from '@lightningjs/solid';
-import styles, { type InputStyles } from './Input.styles.js';
-import type { Tone } from '../../types/types.js';
+import { View, Text } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Input.styles.js';
 
-export interface InputProps extends IntrinsicNodeProps {
+export interface InputProps extends UIComponentProps {
   /**
    * non-reactive index of the current cursor currentPosition
    */
@@ -35,10 +35,6 @@ export interface InputProps extends IntrinsicNodeProps {
    * signal passed in to represent the actual title within the input
    */
   titleSignal: Signal<string>;
-
-  style?: Partial<InputStyles>;
-
-  tone?: Tone;
 }
 
 const Input: Component<InputProps> = props => {
@@ -119,15 +115,14 @@ const Input: Component<InputProps> = props => {
       onLeft={onLeft}
       onRight={onRight}
       style={[
-        props.style?.InputContainer, //
+        props.style, //
         styles.InputContainer.tones[props.tone ?? styles.tone],
         styles.InputContainer.base
       ]}
     >
       <Text
         style={[
-          props.style?.Text, //
-          styles.Text.tones[props.tone ?? styles.tone],
+          styles.Text.tones[props.tone ?? styles.tone], //
           styles.Text.base
         ]}
       >

--- a/src/packages/solid/components/Key/Key.tsx
+++ b/src/packages/solid/components/Key/Key.tsx
@@ -16,17 +16,21 @@
  */
 
 import type { Component } from 'solid-js';
-import { type IntrinsicNodeProps, Text } from '@lightningjs/solid';
+import { Text, type NodeProps } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import { ButtonContainer } from '../Button/Button.jsx';
 import styles, { type KeySize, type KeyStyles } from './Key.styles.js';
-import type { Tone } from '../../types/types.js';
 
-export interface KeyProps extends IntrinsicNodeProps {
+export interface KeyProps extends UIComponentProps {
+  /**
+   * text content of the key
+   */
   title?: string;
+
   /**
    * url for icon
    */
-  icon?: string;
+  icon?: NodeProps['src']; // TODO this isn't used
   /**
    * width of the Key
    */
@@ -34,7 +38,7 @@ export interface KeyProps extends IntrinsicNodeProps {
   /**
    * path to image or inline SVG XML
    */
-  src?: string;
+  src?: NodeProps['src'];
   /**
    * The horizontal spacing between each key in a Keyboard. This value is factored into the width of the key so that it aligns with with the borders of other keys in a Keyboard.
    */
@@ -45,32 +49,27 @@ export interface KeyProps extends IntrinsicNodeProps {
   toggle?: boolean;
 
   keySignal: Partial<KeyStyles>;
-
-  style?: KeyStyles;
-
-  tone?: Tone;
 }
 
 const Key: Component<KeyProps> = props => {
-  const style1 = props?.style ?? styles;
   return (
     <ButtonContainer
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones?.[props.tone ?? styles.tone],
         styles.Container.base
       ]}
       forwardStates
       width={
-        (style1.Container?.tones?.[props.tone ?? styles.tone]?.sizes?.[props.size || 'sm'] ??
-          style1.Container.base.sizes[props.size || 'sm']) *
-          (style1.Container?.tones?.[props.tone ?? styles.tone]?.baseWidth ??
-            style1.Container.base.baseWidth) +
-        (style1.Container.tones?.[props.tone ?? styles.tone]?.keySpacing ??
-          style1.Container.base.keySpacing) *
-          (style1.Container.tones?.[props.tone ?? styles.tone]?.sizes?.[props.size || 'sm'] ??
-            style1.Container.base.sizes[props.size || 'sm'] - 1)
+        (styles.Container?.tones?.[props.tone ?? styles.tone]?.sizes?.[props.size || 'sm'] ??
+          styles.Container.base.sizes[props.size || 'sm']) *
+          (styles.Container?.tones?.[props.tone ?? styles.tone]?.baseWidth ??
+            styles.Container.base.baseWidth) +
+        (styles.Container.tones?.[props.tone ?? styles.tone]?.keySpacing ??
+          styles.Container.base.keySpacing) *
+          (styles.Container.tones?.[props.tone ?? styles.tone]?.sizes?.[props.size || 'sm'] ??
+            styles.Container.base.sizes[props.size || 'sm'] - 1)
       }
       // Keep below for more thought
       //
@@ -85,8 +84,7 @@ const Key: Component<KeyProps> = props => {
     >
       <Text
         style={[
-          props.style?.Text, //
-          styles.Text.tones[props.tone ?? styles.tone],
+          styles.Text.tones[props.tone ?? styles.tone], //
           styles.Text.base
         ]}
       >

--- a/src/packages/solid/components/Keyboard/Keyboard.tsx
+++ b/src/packages/solid/components/Keyboard/Keyboard.tsx
@@ -16,15 +16,14 @@
  */
 
 import { type Component, type Signal } from 'solid-js';
-import { type IntrinsicNodeProps } from '@lightningjs/solid';
-import styles, { type KeyboardStyleProperties, type KeyboardStyles } from './Keyboard.styles.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles, { type KeyboardStyleProperties } from './Keyboard.styles.js';
 import KeyboardSimple from './KeyboardSimple.jsx';
 import type { KeyProps } from '../Key/Key.jsx';
-import type { Tone } from '../../types/types.js';
 
 export type KeyboardFormat = Array<Array<string | KeyProps>>;
 
-export interface KeyboardProps extends IntrinsicNodeProps {
+export interface KeyboardProps extends UIComponentProps {
   /**
    * object containing arrays that represent different formats that the keyboard can be presented in. These arrays can contain strings or objects.
    */
@@ -45,13 +44,15 @@ export interface KeyboardProps extends IntrinsicNodeProps {
    */
   defaultFormat?: string;
 
+  /**
+   * returns the value of the activated key
+   */
   keySignal: Signal<string>;
 
+  /**
+   * gap between keys
+   */
   keySpacing?: KeyboardStyleProperties['keySpacing'];
-
-  style?: Partial<KeyboardStyles>;
-
-  tone?: Tone;
 }
 
 // rows created from each array passed in
@@ -60,7 +61,7 @@ const Keyboard: Component<KeyboardProps> = (props: KeyboardProps) => {
     <KeyboardSimple
       {...props}
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone ?? styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/components/Keyboard/KeyboardSimple.tsx
+++ b/src/packages/solid/components/Keyboard/KeyboardSimple.tsx
@@ -24,6 +24,7 @@ import styles from './Keyboard.styles.js';
 
 // rows created from each array passed in
 const KeyboardSimple: Component<KeyboardProps> = (props: KeyboardProps) => {
+  const [keySignal, setKeySignal] = props.keySignal;
   return (
     <Column
       autofocus={props.autofocus}
@@ -48,7 +49,7 @@ const KeyboardSimple: Component<KeyboardProps> = (props: KeyboardProps) => {
               styles.Container.base.keySpacing
             }
             height={
-              props?.height ??
+              props.height ??
               styles.Container.tones[props.tone ?? styles.tone]?.height ??
               styles.Container.base.height
             }
@@ -57,10 +58,9 @@ const KeyboardSimple: Component<KeyboardProps> = (props: KeyboardProps) => {
             <For each={row}>
               {(key: string | KeyProps) => (
                 <Key
-                  style={props.style?.Key}
                   {...(typeof key === 'string' ? {} : key)}
                   // if not a toggle key
-                  onEnter={() => props.keySignal[1](typeof key === 'string' ? key : key.title ?? '')}
+                  onEnter={() => setKeySignal(typeof key === 'string' ? key : key.title ?? '')}
                   // @ts-expect-error the ternary handles for the type error
                   title={key.title || key.icon ? key.title : key}
                 />

--- a/src/packages/solid/components/Label/Label.styles.ts
+++ b/src/packages/solid/components/Label/Label.styles.ts
@@ -90,7 +90,7 @@ const text: LabelConfig = {
 };
 
 const Container = makeComponentStyles<LabelStyles['Container']>(container);
-const Text = makeComponentStyles<LabelStyles['Container']>(text);
+const Text = makeComponentStyles<LabelStyles['Text']>(text);
 
 const styles: LabelStyles = {
   tone: defaultTone || 'neutral',

--- a/src/packages/solid/components/Label/Label.tsx
+++ b/src/packages/solid/components/Label/Label.tsx
@@ -1,12 +1,11 @@
 import { type Component } from 'solid-js';
 import { Text } from '@lightningjs/solid';
-import type { IntrinsicNodeProps } from '@lightningjs/solid';
-import styles, { type LabelStyles, type LabelStyleProperties } from './Label.styles.js';
 import { withPadding } from '@lightningjs/solid-primitives';
-import type { Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles, { type LabelStyleProperties } from './Label.styles.js';
 withPadding;
 
-export interface LabelProps extends IntrinsicNodeProps {
+export interface LabelProps extends UIComponentProps {
   /**
    * text to display in label
    */
@@ -29,7 +28,7 @@ const Label: Component<LabelProps> = props => {
       }
       {...props}
       style={[
-        ...[props.style].flat(), //
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}
@@ -37,8 +36,7 @@ const Label: Component<LabelProps> = props => {
     >
       <Text
         style={[
-          props.style?.Text, //
-          styles.Text.tones[props.tone || styles.tone],
+          styles.Text.tones[props.tone || styles.tone], //
           styles.Text.base
         ]}
       >

--- a/src/packages/solid/components/Metadata/Details.tsx
+++ b/src/packages/solid/components/Metadata/Details.tsx
@@ -16,14 +16,13 @@
  */
 import type { Component, Accessor } from 'solid-js';
 import { View, Text, Show, For } from '@lightningjs/solid';
-import type { IntrinsicNodeProps, ElementNode } from '@lightningjs/solid';
+import type { ElementNode } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Details.styles.js';
 import Badge, { type BadgeProps } from '../Badge/Badge.jsx';
 import Rating, { type RatingProps } from './Rating.jsx';
-import styles from './Details.styles.js';
-import { type DetailsStyles } from './Details.styles.js';
-import type { Tone } from '../../types/types.js';
 
-export interface DetailsProps extends IntrinsicNodeProps {
+export interface DetailsProps extends UIComponentProps {
   /**
    * an array of BadgeProps to render [Badges](?path=/docs/components-badge--docs)
    */
@@ -36,17 +35,13 @@ export interface DetailsProps extends IntrinsicNodeProps {
    * text to display as details title
    */
   title?: string;
-
-  style?: Partial<DetailsStyles>;
-
-  tone?: Tone;
 }
 
 const Details: Component<DetailsProps> = (props: DetailsProps) => {
   return (
     <View
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}
@@ -62,8 +57,7 @@ const Details: Component<DetailsProps> = (props: DetailsProps) => {
       <Show when={props.title}>
         <Text
           style={[
-            props.style?.Text, //
-            styles.Text.tones[props.tone || styles.tone],
+            styles.Text.tones[props.tone || styles.tone], //
             styles.Text.base
           ]}
         >
@@ -76,11 +70,9 @@ const Details: Component<DetailsProps> = (props: DetailsProps) => {
             {...badge}
             marginRight={
               props.badges?.length && idx() === props.badges.length - 1
-                ? props.style?.Container?.contentSpacing ??
-                  styles.Container.tones[props.tone ?? styles.tone]?.contentSpacing ??
+                ? styles.Container.tones[props.tone ?? styles.tone]?.contentSpacing ??
                   styles.Container.base.contentSpacing
-                : props.style?.Container?.badgeContentSpacing ??
-                  styles.Container.tones[props.tone ?? styles.tone]?.badgeContentSpacing ??
+                : styles.Container.tones[props.tone ?? styles.tone]?.badgeContentSpacing ??
                   styles.Container.base.badgeContentSpacing
             }
           />
@@ -91,16 +83,14 @@ const Details: Component<DetailsProps> = (props: DetailsProps) => {
           <Rating
             {...rating}
             style={[
-              props.style?.Text, //
-              styles.Text.tones[props.tone || styles.tone],
+              styles.Text.tones[props.tone || styles.tone], //
               styles.Text.base
             ]}
             forwardStates
             marginRight={
               props.ratings?.length && idx() === props.ratings.length - 1
                 ? 0
-                : props.style?.Container?.ratingContentSpacing ??
-                  styles.Container.tones[props.tone ?? styles.tone]?.ratingContentSpacing ??
+                : styles.Container.tones[props.tone ?? styles.tone]?.ratingContentSpacing ??
                   styles.Container.base.ratingContentSpacing
             }
           />

--- a/src/packages/solid/components/Metadata/Metadata.tsx
+++ b/src/packages/solid/components/Metadata/Metadata.tsx
@@ -16,12 +16,11 @@
  */
 import { type Component } from 'solid-js';
 import { View, Text, Show } from '@lightningjs/solid';
-import type { NodeStyles } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import Details, { type DetailsProps } from './Details.jsx';
-import styles, { type MetadataStyles } from './Metadata.styles.js';
-import type { Tone } from '../../types/types.js';
+import styles from './Metadata.styles.js';
 
-export interface MetadataProps extends NodeStyles {
+export interface MetadataProps extends UIComponentProps {
   /**
    * title text
    */
@@ -34,11 +33,10 @@ export interface MetadataProps extends NodeStyles {
    * Text, Badges, and Icons to be displayed below the title and description
    */
   details: DetailsProps;
+
+  // width: UIComponentProps['width'];
+
   maxLines: number;
-
-  style?: Partial<MetadataStyles>;
-
-  tone?: Tone;
 }
 
 const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
@@ -46,8 +44,8 @@ const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
     <View
       {...props}
       style={[
-        ...[props.style].flat(),
-        styles.Container.tones[props.tone || styles.tone],
+        props.style,
+        styles.Container.tones[props.tone || styles.tone], //
         styles.Container.base
       ]}
       forwardStates
@@ -55,8 +53,7 @@ const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
       <Text
         width={props.width}
         style={[
-          props.style?.TitleText, //
-          styles.TitleText.tones[props.tone || styles.tone],
+          styles.TitleText.tones[props.tone || styles.tone], //
           styles.TitleText.base
         ]}
       >
@@ -66,8 +63,7 @@ const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
         <Text
           width={props.width}
           style={[
-            props.style?.DescriptionText,
-            styles.DescriptionText.tones[props.tone || styles.tone],
+            styles.DescriptionText.tones[props.tone || styles.tone], //
             styles.DescriptionText.base
           ]}
         >

--- a/src/packages/solid/components/Metadata/Rating.tsx
+++ b/src/packages/solid/components/Metadata/Rating.tsx
@@ -15,14 +15,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Component, createMemo } from 'solid-js';
-import { Text, Show, View } from '@lightningjs/solid';
-import type { IntrinsicNodeProps } from '@lightningjs/solid';
+import { Text, Show, View, type TextProps } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Rating.styles.js';
 import Icon from '../Icon/Icon.jsx';
 import type { IconProps } from '../Icon/Icon.jsx';
-import styles, { type RatingStyles } from './Rating.styles.js';
-import type { Tone } from '../../types/types.js';
 
-export interface RatingProps extends IntrinsicNodeProps {
+export interface RatingProps extends UIComponentProps {
   /**
    * path to the rating's icon
    */
@@ -30,15 +29,11 @@ export interface RatingProps extends IntrinsicNodeProps {
   /**
    * Text or number to display. Numbers from 0 to 100 will display as percentages.
    */
-  title: string;
-
-  style?: Partial<RatingStyles>;
-
-  tone?: Tone;
+  title: string | number;
 }
 
 const Rating: Component<RatingProps> = (props: RatingProps) => {
-  const formatTitle = (title: string | number) => {
+  const formatTitle = (title: string | number): TextProps['children'] => {
     if ((typeof title !== 'string' && typeof title !== 'number') || !String(title).trim().length) {
       return;
     }
@@ -47,7 +42,7 @@ const Rating: Component<RatingProps> = (props: RatingProps) => {
     if (!Number.isNaN(title) && Number(title) >= 0 && Number(title) <= 100) {
       formatted += '%';
     }
-    return formatted;
+    return formatted as string;
   };
   const formattedTitle = createMemo(() => formatTitle(props.title));
   return (
@@ -55,7 +50,7 @@ const Rating: Component<RatingProps> = (props: RatingProps) => {
       {...props}
       forwardStates
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}
@@ -65,8 +60,7 @@ const Rating: Component<RatingProps> = (props: RatingProps) => {
           forwardStates
           src={props.src}
           style={[
-            props.style?.Icon, //
-            styles.Icon.tones[props.tone || styles.tone],
+            styles.Icon.tones[props.tone || styles.tone], //
             styles.Icon.base
           ]}
         />
@@ -75,8 +69,7 @@ const Rating: Component<RatingProps> = (props: RatingProps) => {
         <Text
           marginRight={props.marginRight}
           style={[
-            props.style?.Text, //
-            styles.Text.tones[props.tone || styles.tone],
+            styles.Text.tones[props.tone || styles.tone], //
             styles.Text.base
           ]}
         >

--- a/src/packages/solid/components/ProgressBar/ProgressBar.tsx
+++ b/src/packages/solid/components/ProgressBar/ProgressBar.tsx
@@ -16,12 +16,11 @@
  */
 
 import type { Component } from 'solid-js';
-import { View, type NodeProps } from '@lightningjs/solid';
+import { View } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import styles from './ProgressBar.styles.js';
-import type { Tone } from '../../types/types.js';
-import { type ProgressBarStyles } from './ProgressBar.styles.js';
 
-export interface ProgressBarProps extends NodeProps {
+export interface ProgressBarProps extends UIComponentProps {
   /**
    * a numeric value of the current progress represented as a decimal between 0 and 1
    */
@@ -39,10 +38,6 @@ export interface ProgressBarProps extends NodeProps {
    * total height of the component
    */
   height?: number;
-
-  tone: Tone;
-
-  style?: Partial<ProgressBarStyles>;
 }
 
 const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
@@ -51,7 +46,7 @@ const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
       {...props}
       forwardStates
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}
@@ -62,8 +57,7 @@ const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
         width={props.width * props.progress}
         color={props.progressColor}
         style={[
-          props.style?.ProgressBar,
-          styles.ProgressBar.tones[props.tone || styles.tone],
+          styles.ProgressBar.tones[props.tone || styles.tone], //
           styles.ProgressBar.base
         ]}
       />

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -16,15 +16,15 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, ElementNode, type NodeProps } from '@lightningjs/solid';
+import { View, ElementNode } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
-import styles, { type RowStyles } from './Row.styles.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import { chainFunctions } from '../../utils/chainFunctions.js';
 import { handleNavigation, onGridFocus } from '../../utils/handleNavigation.js';
-import { withScrolling } from '../../utils/withScrolling.js';
-import { chainFunctions } from '../../index.js';
-import type { Tone } from '../../types/types.js';
+import { withScrolling, type ScrollableElementNode } from '../../utils/withScrolling.js';
+import styles from './Row.styles.js';
 
-export interface RowProps extends NodeProps {
+export interface RowProps extends UIComponentProps {
   /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
 
@@ -56,10 +56,6 @@ export interface RowProps extends NodeProps {
     selectedIndex: number,
     lastSelectedIndex: number
   ) => void;
-
-  tone?: Tone;
-
-  style?: Partial<RowStyles>;
 }
 
 const Row: Component<RowProps> = (props: RowProps) => {
@@ -91,13 +87,11 @@ const Row: Component<RowProps> = (props: RowProps) => {
         props.onSelectedChanged,
         props.scroll !== 'none' ? withScrolling(props.x as number) : undefined
       )}
-      tone={props.tone ?? styles.tone}
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone || styles.tone],
         styles.Container.base
       ]}
-      states={props.tone ?? styles.tone}
     />
   );
 };

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -65,10 +65,13 @@ export interface RowProps extends NodeProps {
 const Row: Component<RowProps> = (props: RowProps) => {
   const onLeft = handleNavigation('left');
   const onRight = handleNavigation('right');
+  let Container: ScrollableElementNode;
 
   return (
     <View
       {...props}
+      // @ts-expect-error this is fine
+      ref={Container}
       selected={props.selected || 0}
       onLeft={chainFunctions(props.onLeft, onLeft)}
       onRight={chainFunctions(props.onRight, onRight)}

--- a/src/packages/solid/components/Row/Row.tsx
+++ b/src/packages/solid/components/Row/Row.tsx
@@ -16,7 +16,7 @@
  */
 
 import { type Component } from 'solid-js';
-import { View, ElementNode } from '@lightningjs/solid';
+import { View, ElementNode, type IntrinsicNodeCommonProps } from '@lightningjs/solid';
 import type { KeyHandler } from '@lightningjs/solid-primitives';
 import type { UIComponentProps } from '../../types/interfaces.js';
 import { chainFunctions } from '../../utils/chainFunctions.js';
@@ -25,6 +25,8 @@ import { withScrolling, type ScrollableElementNode } from '../../utils/withScrol
 import styles from './Row.styles.js';
 
 export interface RowProps extends UIComponentProps {
+  /** function run on component mount */
+  onCreate?: IntrinsicNodeCommonProps['onCreate'];
   /** When auto scrolling, item index at which scrolling begins */
   scrollIndex?: number;
 
@@ -72,8 +74,8 @@ const Row: Component<RowProps> = (props: RowProps) => {
       onLeft={chainFunctions(props.onLeft, onLeft)}
       onRight={chainFunctions(props.onRight, onRight)}
       forwardFocus={onGridFocus}
-      onCreate={chainFunctions(
-        elm =>
+      onCreate={chainFunctions<RowProps['onCreate']>(
+        (elm: ScrollableElementNode) =>
           withScrolling(props.x as number).call(
             elm,
             elm,

--- a/src/packages/solid/components/Tile/Tile.tsx
+++ b/src/packages/solid/components/Tile/Tile.tsx
@@ -1,13 +1,30 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { type Component, createSignal } from 'solid-js';
 import { Show, type NodeProps, View } from '@lightningjs/solid';
 import { withPadding } from '@lightningjs/solid-primitives';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import Artwork, { type ArtworkProps } from '../Artwork/Artwork.jsx';
 import ProgressBar, { type ProgressBarProps } from '../ProgressBar/ProgressBar.jsx';
-import styles, { type TileStyleProperties, type TileStyles } from './Tile.styles.js';
-import type { Tone } from '../../types/types.js';
+import styles, { type TileStyleProperties } from './Tile.styles.js';
 withPadding;
 
-export interface TileProps extends NodeProps {
+export interface TileProps extends UIComponentProps {
   /**
    * prop object passed to the child Artwork component
    */
@@ -76,10 +93,6 @@ export interface TileProps extends NodeProps {
   paddingYProgress: TileStyleProperties['paddingYProgress'];
 
   padding: number[];
-
-  tone?: Tone;
-
-  style?: Partial<TileStyles>;
 }
 
 const Tile: Component<TileProps> = (props: TileProps) => {
@@ -95,7 +108,7 @@ const Tile: Component<TileProps> = (props: TileProps) => {
       onFocus={() => setIsFocused(true)}
       onBlur={() => setIsFocused(false)}
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones[props.tone ?? styles.tone],
         styles.Container.base
       ]}
@@ -125,7 +138,7 @@ const Tile: Component<TileProps> = (props: TileProps) => {
 
         <View
           x={
-            (props?.width ??
+            (props.width ??
               styles.Container.tones[props.tone ?? styles.tone]?.width ??
               styles.Container.base.width) -
             (props.padding?.[0] ??
@@ -144,8 +157,7 @@ const Tile: Component<TileProps> = (props: TileProps) => {
 
         <View
           style={[
-            props.style?.InsetBottom,
-            styles.InsetBottom.tones[props.tone ?? styles.tone],
+            styles.InsetBottom.tones[props.tone ?? styles.tone], //
             styles.InsetBottom.base
           ]}
           width={
@@ -178,8 +190,7 @@ const Tile: Component<TileProps> = (props: TileProps) => {
 
         <View
           style={[
-            props.style?.StandardBottom,
-            styles.StandardBottom.tones[props.tone ?? styles.tone],
+            styles.StandardBottom.tones[props.tone ?? styles.tone], //
             styles.StandardBottom.base
           ]}
           x={

--- a/src/packages/solid/components/Toggle/Toggle.tsx
+++ b/src/packages/solid/components/Toggle/Toggle.tsx
@@ -16,18 +16,16 @@
  */
 
 import { createMemo, type Component } from 'solid-js';
-import { View, type NodeProps } from '@lightningjs/solid';
-import styles, { type ToggleStyles } from './Toggle.styles.js';
-import type { Tone } from '../../types/types.js';
+import { View } from '@lightningjs/solid';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import styles from './Toggle.styles.js';
 
-export interface ToggleProps extends NodeProps {
+export interface ToggleProps extends UIComponentProps {
   /**
    * Indicates whether the Toggle is checked or unchecked.
    * Setting this to `true` will check the toggle, and setting it to `false` will uncheck it.
    */
   checked?: boolean;
-  tone?: Tone;
-  style?: Partial<ToggleStyles>;
 }
 
 const Toggle: Component<ToggleProps> = (props: ToggleProps) => {
@@ -54,9 +52,8 @@ const Toggle: Component<ToggleProps> = (props: ToggleProps) => {
   return (
     <View
       {...props}
-      // tone={props.tone ?? styles.tone}
       style={[
-        ...[props.style].flat(),
+        props.style, //
         styles.Container.tones?.[props.tone ?? styles.tone],
         styles.Container.base
       ]}

--- a/src/packages/solid/tsconfig.json
+++ b/src/packages/solid/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["./components/**/*", "./utils/**/*", "../../shared/types/solid.d.ts", "*.ts", "*.tsx"],
+  "include": [
+    "./components/**/*",
+    "./utils/**/*",
+    "./types/**/*",
+    "../../shared/types/solid.d.ts",
+    "*.ts",
+    "*.tsx"
+  ],
   "rootDir": "../../",
   "compilerOptions": {
     "outDir": "./dist",

--- a/src/packages/solid/types/interfaces.d.ts
+++ b/src/packages/solid/types/interfaces.d.ts
@@ -18,10 +18,6 @@
 import { type IntrinsicNodeProps, type IntrinsicNodeStyleProps } from '@lightningjs/solid';
 import type { Tone } from './types.js';
 
-type AddUndefined<T> = {
-  [K in keyof T]: T[K] | undefined;
-};
-
 // TODO extends NodeProps, we may want to narrow this
 /**
  * ensures all our components provide the same API for tone

--- a/src/packages/solid/types/interfaces.d.ts
+++ b/src/packages/solid/types/interfaces.d.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NodeProps } from '@lightningjs/solid';
+import { type IntrinsicNodeProps, type IntrinsicNodeStyleProps } from '@lightningjs/solid';
 import type { Tone } from './types.js';
 
 type AddUndefined<T> = {
@@ -29,15 +29,13 @@ type AddUndefined<T> = {
  * overrides color - strings are accepted by the renderer even though the type
  * is number, and all our colors are strings due to JSON limitations
  */
-export interface UIComponentProps extends Omit<NodeProps, 'children'> {
-  color?: NodeProps['color'] & string;
+export interface UIComponentProps extends IntrinsicNodeStyleProps {
+  color?: IntrinsicNodeStyleProps['color'] & string;
+
   /**
-   * applied to the root node of the component, primarily used to handle state-based styling
-   * ie.
-   * Component.style.alpha = 0
-   * Component.style.focus.alpha = 1
+   * applied to the component's root node
    */
-  style?: NodeProps | NodeProps[] | undefined | undefined[];
+  style?: IntrinsicNodeProps['style'];
 
   /**
    * sets the component's color palette

--- a/src/packages/solid/types/interfaces.d.ts
+++ b/src/packages/solid/types/interfaces.d.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeProps } from '@lightningjs/solid';
+import type { Tone } from './types.js';
+
+type AddUndefined<T> = {
+  [K in keyof T]: T[K] | undefined;
+};
+
+// TODO extends NodeProps, we may want to narrow this
+/**
+ * ensures all our components provide the same API for tone
+ * omits children, not all ui-components support children
+ * overrides color - strings are accepted by the renderer even though the type
+ * is number, and all our colors are strings due to JSON limitations
+ */
+export interface UIComponentProps extends Omit<NodeProps, 'children'> {
+  color?: NodeProps['color'] & string;
+  /**
+   * applied to the root node of the component, primarily used to handle state-based styling
+   * ie.
+   * Component.style.alpha = 0
+   * Component.style.focus.alpha = 1
+   */
+  style?: NodeProps | NodeProps[] | undefined | undefined[];
+
+  /**
+   * sets the component's color palette
+   */
+  tone?: Tone;
+}

--- a/src/packages/solid/utils/chainFunctions.ts
+++ b/src/packages/solid/utils/chainFunctions.ts
@@ -15,9 +15,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable @typescript-eslint/ban-types */
+export function chainFunctions(...args: unknown[]): unknown;
+export function chainFunctions<T>(...args: (unknown | T)[]): T;
+
 // take an array of functions and if you return true from a function, it will stop the chain
-export const chainFunctions = (...args: (Function | undefined)[]) => {
+export function chainFunctions<T>(...args: (unknown | T)[]) {
   const onlyFunctions = args.filter(func => typeof func === 'function') as Function[];
   if (onlyFunctions.length === 0) {
     return undefined;
@@ -27,7 +29,7 @@ export const chainFunctions = (...args: (Function | undefined)[]) => {
     return onlyFunctions[0];
   }
 
-  return function (...innerArgs: unknown[]) {
+  return function (this: unknown, ...innerArgs: unknown[]) {
     let result;
     for (const func of onlyFunctions) {
       result = func.apply(this, innerArgs);
@@ -37,4 +39,4 @@ export const chainFunctions = (...args: (Function | undefined)[]) => {
     }
     return result;
   };
-};
+}

--- a/src/packages/solid/utils/withScrolling.ts
+++ b/src/packages/solid/utils/withScrolling.ts
@@ -17,12 +17,18 @@
 
 import type { ElementNode } from '@lightningjs/solid';
 
+// adds properties expected by withScrolling
+export interface ScrollableElementNode extends ElementNode {
+  scrollIndex: number;
+  selected: number;
+}
+
 export function withScrolling(adjustment: number = 0) {
   return (
-    componentRef: ElementNode,
+    componentRef: ScrollableElementNode,
     selectedElement: ElementNode,
     selected: number = 0,
-    lastSelected: number
+    lastSelected: number | undefined
   ) => {
     if (componentRef.children.length === 0) {
       return;
@@ -113,20 +119,20 @@ export function withScrolling(adjustment: number = 0) {
   };
 }
 
-function updateLastIndex(items) {
+function updateLastIndex(items: ElementNode): [{ position: number; size: number }, number] {
   let lastItem, containerSize;
   if (items.flexDirection === 'row') {
     lastItem = {
-      position: items.children[items.children.length - 1].x,
-      size: items.children[items.children.length - 1].width
+      position: items.children[items.children.length - 1].x ?? 0,
+      size: items.children[items.children.length - 1].width ?? 0
     };
-    containerSize = items.width;
+    containerSize = items.width ?? 0;
   } else {
     lastItem = {
-      position: items.children[items.children.length - 1].y,
-      size: items.children[items.children.length - 1].height
+      position: items.children[items.children.length - 1].y ?? 0,
+      size: items.children[items.children.length - 1].height ?? 0
     };
-    containerSize = items.height;
+    containerSize = items.height ?? 0;
   }
 
   return [lastItem, containerSize];


### PR DESCRIPTION
## Description

This PR updates our components to utilize the latest style API, as well as adding a base level prop interface for all of our components to implement

known issues: the `style` prop on Views and Texts is currently throwing a type error for props.style. the type needs to be updated to allow nested arrays

**update**: this also includes some type updates to the `chainFunctions` utility that should resolve the errors that we were attempting to resolve in PR https://github.com/lightning-js/ui-components/pull/103

## Changes
- replaces all instances of `...[props.style].flat()` with `props.style`, thanks to solid's latest update to accept nested style arrays
- updates component prop types to leverage the solid node types where applicable
- adds `UIComponentProps` interface to ensure all of our components implement the same standard props(tone, styles, a patch for color)
- components that accept children must now explicitly define the children type
- improves the type safety and overall resilience of the `withScrolling` utility

## Testing

- ensure all components still render as expected
- build the project and ensure it loads correctly in client applications

