### PR TITLE
fix(CardContent): allows users to add columnSpan as prop

### DIFF
--- a/src/packages/solid/components/CardContent/CardContent.stories.tsx
+++ b/src/packages/solid/components/CardContent/CardContent.stories.tsx
@@ -49,6 +49,14 @@ const meta: Meta<typeof CardContent> = {
       control: { type: 'radio' },
       options: [true, false]
     },
+    metadataColumnSpan: {
+      description: 'sets the number of columns the metadata section spans',
+      control: { type: 'number', step: 1, min: 0, max: 10 }
+    },
+    tileColumnSpan: {
+      description: 'sets the number of columns the tile section spans',
+      control: { type: 'number', step: 1, min: 0, max: 10 }
+    },
     progressBar: {
       description: 'object containing all the properties supported in the ProgressBar component',
       color: {
@@ -114,7 +122,9 @@ export const Basic: Story = {
     },
     progressBar: {
       progress: 0.5
-    }
+    },
+    tileColumnSpan: 3,
+    metadataColumnSpan: 3
   }
 };
 

--- a/src/packages/solid/components/CardContent/CardContent.styles.ts
+++ b/src/packages/solid/components/CardContent/CardContent.styles.ts
@@ -18,7 +18,7 @@
 import type { NodeStyles } from '@lightningjs/solid';
 import theme from 'theme';
 import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
-import { makeComponentStyles, getDimensions, getWidthByUpCount } from '../../utils/index.js';
+import { makeComponentStyles, getDimensions, getWidthByColumnSpan } from '../../utils/index.js';
 
 export interface CardContentStyles {
   tone: Tone;
@@ -41,7 +41,6 @@ const { CardContent: { defaultTone, ...cardContentthemeStyles } = { styles: {} }
 const container: CardContentConfig = {
   themeKeys: {},
   base: {
-    width: getWidthByUpCount(theme, 2),
     height:
       getDimensions({
         ratioX: 16,
@@ -80,7 +79,7 @@ const metadataContainer: CardContentConfig = {
     color: 'backgroundColor'
   },
   base: {
-    width: (getWidthByUpCount(theme, 2) ?? 0) - getDimensions({ ratioX: 16, ratioY: 9, upCount: 4 }).w,
+    width: getWidthByColumnSpan(3),
     height: getDimensions({ ratioX: 16, ratioY: 9, upCount: 4 }).h,
     color: theme.color.fillInverseSecondary,
     padding: [theme.spacer.xl, theme.spacer.xl],

--- a/src/packages/solid/components/CardContent/CardContent.tsx
+++ b/src/packages/solid/components/CardContent/CardContent.tsx
@@ -22,6 +22,7 @@ import type { Tone } from '../../types/types.js';
 import { type ArtworkProps } from '../Artwork/Artwork.jsx';
 import type { ProgressBarProps } from '../ProgressBar/ProgressBar.jsx';
 import Tile from '../Tile/Tile.jsx';
+import { getWidthByColumnSpan } from '../../utils/index.js';
 withPadding; // Preserve the import.
 
 export interface CardContentProps extends NodeProps {
@@ -101,6 +102,14 @@ export interface CardContentProps extends NodeProps {
    */
   metadataBottom?: NodeProps['children'];
   /**
+   * sets the number of columns the metadata section spans
+   */
+  metadataColumnSpan?: number;
+  /**
+   * sets the number of columns the tile section spans
+   */
+  tileColumnSpan?: number;
+  /**
    * sets the component's color palette
    */
   tone?: Tone;
@@ -143,11 +152,9 @@ const CardContent: Component<CardContentProps> = props => {
         states={{ collapsed: collapsedTile() }}
         style={[styles.TileContainer.tones[props.tone ?? styles.tone], styles.TileContainer.base]}
         width={
-          styles.TileContainer.tones[props.tone ?? styles.tone]?.width ?? styles.TileContainer.base.width
+          props.tileColumnSpan ? getWidthByColumnSpan(props.tileColumnSpan) : styles.TileContainer.base.width
         }
-        height={
-          styles.TileContainer.tones[props.tone ?? styles.tone]?.height ?? styles.TileContainer.base.height
-        }
+        height={props.height || styles.TileContainer.base.height}
         persistentMetadata={!props.shouldCollapse}
       />
 
@@ -155,30 +162,19 @@ const CardContent: Component<CardContentProps> = props => {
       <Show when={!collapsedTile()}>
         <View
           style={[styles.MetadataContainer.tones[props.tone ?? styles.tone], styles.MetadataContainer.base]}
+          width={
+            props.metadataColumnSpan
+              ? getWidthByColumnSpan(props.metadataColumnSpan)
+              : styles.MetadataContainer.base.width
+          }
+          height={props.height || styles.MetadataContainer.base.height}
         >
-          <View
-            x={
-              styles.MetadataContainer.tones[props.tone ?? styles.tone]?.padding?.[0] ??
-              styles.MetadataContainer.base.padding[0]
-            }
-            y={
-              styles.MetadataContainer.tones[props.tone ?? styles.tone]?.padding?.[1] ??
-              styles.MetadataContainer.base.padding[1]
-            }
-          >
+          <View x={styles.MetadataContainer.base.padding[0]} y={styles.MetadataContainer.base.padding[1]}>
             {props.metadataTop}
           </View>
           <View
-            x={
-              styles.MetadataContainer.tones[props.tone ?? styles.tone]?.padding?.[0] ??
-              styles.MetadataContainer.base.padding[0]
-            }
-            y={
-              (styles.MetadataContainer.tones[props.tone ?? styles.tone]?.height ??
-                styles.MetadataContainer.base.height) -
-              (styles.MetadataContainer.tones[props.tone ?? styles.tone]?.padding?.[1] ??
-                styles.MetadataContainer.base.padding[1])
-            }
+            x={styles.MetadataContainer.base.padding[0]}
+            y={styles.MetadataContainer.base.height - styles.MetadataContainer.base.padding[1]}
             mountY={1}
           >
             {props.metadataBottom}

--- a/src/packages/solid/components/CardContent/CardContent.tsx
+++ b/src/packages/solid/components/CardContent/CardContent.tsx
@@ -154,7 +154,7 @@ const CardContent: Component<CardContentProps> = props => {
         width={
           props.tileColumnSpan ? getWidthByColumnSpan(props.tileColumnSpan) : styles.TileContainer.base.width
         }
-        height={props.height || styles.TileContainer.base.height}
+        height={props.height ?? styles.TileContainer.base.height}
         persistentMetadata={!props.shouldCollapse}
       />
 
@@ -167,7 +167,7 @@ const CardContent: Component<CardContentProps> = props => {
               ? getWidthByColumnSpan(props.metadataColumnSpan)
               : styles.MetadataContainer.base.width
           }
-          height={props.height || styles.MetadataContainer.base.height}
+          height={props.height ?? styles.MetadataContainer.base.height}
         >
           <View x={styles.MetadataContainer.base.padding[0]} y={styles.MetadataContainer.base.padding[1]}>
             {props.metadataTop}

--- a/src/packages/solid/components/Input/Input.styles.ts
+++ b/src/packages/solid/components/Input/Input.styles.ts
@@ -20,7 +20,7 @@ import theme from 'theme';
 import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
-import { getWidthByUpCount } from '../../utils/getWidthByUpcount.js';
+import { getWidthByUpCount } from '../../utils/getWidthByUpCount.js';
 
 export interface InputStyles {
   tone: Tone;
@@ -62,7 +62,7 @@ const input: InputConfig = {
     color: 'backgroundColor'
   },
   base: {
-    width: getWidthByUpCount(theme, 4),
+    width: getWidthByUpCount(4),
     height: 100,
     display: 'flex',
     flexDirection: 'column',

--- a/src/packages/solid/components/Tile/Tile.tsx
+++ b/src/packages/solid/components/Tile/Tile.tsx
@@ -102,6 +102,8 @@ const Tile: Component<TileProps> = (props: TileProps) => {
     >
       <Artwork
         {...props.artwork}
+        width={props.width}
+        height={props.height}
         states={props.states}
         style={props.style}
         tone={props.tone ?? styles.tone}

--- a/src/packages/solid/utils/getDimensions.ts
+++ b/src/packages/solid/utils/getDimensions.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getItemRatioDimensions } from './getItemRatioDimensions.js';
-import theme from 'theme';
+import { getWidthByUpCount } from './getWidthByUpCount.js';
 
 export function getDimensions(obj = {}, fallback = {}) {
   const { w, h, ratioX, ratioY, upCount } = obj;
@@ -41,7 +41,7 @@ export function getDimensions(obj = {}, fallback = {}) {
   } else if (h && upCount) {
     // calculate dynamic width based off a row upcount and a given height
     dimensions = {
-      w: Math.round(getWidthByUpCount(theme, upCount)),
+      w: Math.round(getWidthByUpCount(upCount)),
       h: h
     };
   } else if (h) {

--- a/src/packages/solid/utils/getWidthByColumnSpan.ts
+++ b/src/packages/solid/utils/getWidthByColumnSpan.ts
@@ -14,17 +14,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+import theme from 'theme';
 import { getWidthByUpCount } from './getWidthByUpCount.js';
+export function getWidthByColumnSpan(columnSpan: number) {
+  const columnCount = theme.layout.columnCount;
+  const gutterX = theme.layout.gutterX;
 
-export function getItemRatioDimensions(ratioX: number, ratioY: number, upCount: number) {
-  let w, h;
-
-  if (ratioX && ratioY && upCount) {
-    w = Math.round(getWidthByUpCount(upCount) ?? 0);
-    h = Math.round((w / ratioX) * ratioY);
-  } else {
-    w = 0;
-    h = 0;
-  }
-  return { w, h };
+  return (getWidthByUpCount(columnCount) ?? 1) * columnSpan + gutterX * (columnSpan - 1);
 }

--- a/src/packages/solid/utils/getWidthByUpcount.ts
+++ b/src/packages/solid/utils/getWidthByUpcount.ts
@@ -14,7 +14,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-export function getWidthByUpCount(theme, upCount = 1) {
+import theme from 'theme';
+export function getWidthByUpCount(upCount = 1) {
   const screenW = theme.layout.screenW;
   const columnCount = theme.layout.columnCount;
   const marginX = theme.layout.marginX;

--- a/src/packages/solid/utils/index.ts
+++ b/src/packages/solid/utils/index.ts
@@ -22,6 +22,7 @@ export { chainFunctions } from './chainFunctions.js';
 export { assertTruthy } from './assertTruthy.js';
 export { handleNavigation, onGridFocus } from './handleNavigation.js';
 export { scrollToIndex } from './scrollToIndex.js';
-export { getWidthByUpCount } from './getWidthByUpcount.js';
+export { getWidthByUpCount } from './getWidthByUpCount.js';
+export { getWidthByColumnSpan } from './getWidthByColumnSpan.js';
 export { getItemRatioDimensions } from './getItemRatioDimensions.js';
 export { getDimensions } from './getDimensions.js';


### PR DESCRIPTION
## Description

Adds a `metadataColumnSpan` and `tileColumnSpan` prop so users can control the size of cardContent

## Changes

- `metadataColumnSpan` prop
- `tileColumnSpan` prop 

## Testing

- change values in these added properties to see component change
