### PR TITLE
feat(utils): add HOC to create toned components

### DIFF
--- a/src/packages/solid/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/packages/solid/components/ProgressBar/ProgressBar.stories.tsx
@@ -19,6 +19,8 @@ import ProgressBar from './ProgressBar.js';
 import type { Meta, StoryObj } from 'storybook-solidjs';
 import theme from 'theme';
 import { hexColor } from '@lightningjs/solid';
+import createComponentWithTone from '../../utils/createComponentWithTone.jsx';
+import styles from './ProgressBar.styles.js';
 
 type Story = StoryObj<typeof ProgressBar>;
 
@@ -27,14 +29,6 @@ const meta: Meta<typeof ProgressBar> = {
   component: ProgressBar,
   tags: ['autodocs'],
   argTypes: {
-    color: {
-      description: 'color of bar representing the total progress',
-      control: 'color'
-    },
-    progressColor: {
-      description: 'color of bar representing the current progress',
-      control: 'color'
-    },
     progress: {
       description: 'Percentage of current progress in a decimal format from 0 to 1',
       control: { type: 'number', step: 0.1, min: 0, max: 1.0 }
@@ -57,6 +51,30 @@ export const Basic: Story = {
         color={hexColor(args.color) || undefined}
       />
     );
+  },
+  argTypes: {
+    color: {
+      description: 'color of bar representing the total progress',
+      control: 'color'
+    },
+    progressColor: {
+      description: 'color of bar representing the current progress',
+      control: 'color'
+    }
+  },
+  args: {
+    width: 500,
+    height: theme.spacer.md,
+    progress: 0.5,
+    borderRadius: theme.radius.xs
+  }
+};
+
+const ProgressBarBrand = createComponentWithTone(ProgressBar, 'brand', styles);
+
+export const Brand: Story = {
+  render: args => {
+    return <ProgressBarBrand {...args} />;
   },
   args: {
     width: 500,

--- a/src/packages/solid/components/ProgressBar/ProgressBar.tsx
+++ b/src/packages/solid/components/ProgressBar/ProgressBar.tsx
@@ -18,7 +18,7 @@
 import type { Component } from 'solid-js';
 import { View } from '@lightningjs/solid';
 import type { UIComponentProps } from '../../types/interfaces.js';
-import styles from './ProgressBar.styles.js';
+import styles, { type ProgressBarStyles } from './ProgressBar.styles.js';
 
 export interface ProgressBarProps extends UIComponentProps {
   /**
@@ -38,9 +38,14 @@ export interface ProgressBarProps extends UIComponentProps {
    * total height of the component
    */
   height?: number;
+
+  toned?: boolean;
+
+  toneStyles?: Omit<ProgressBarStyles, 'tone'>;
 }
 
 const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
+  const toneStyles = props.toneStyles;
   return (
     <View
       {...props}
@@ -48,7 +53,7 @@ const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
       // @ts-expect-error TODO type needs to be fixed in framework
       style={[
         props.style, //
-        styles.Container.tones[props.tone || styles.tone],
+        toneStyles?.Container,
         styles.Container.base
       ]}
     >
@@ -58,7 +63,7 @@ const ProgressBar: Component<ProgressBarProps> = (props: ProgressBarProps) => {
         width={props.width * props.progress}
         color={props.progressColor}
         style={[
-          styles.ProgressBar.tones[props.tone || styles.tone], //
+          toneStyles?.ProgressBar, //
           styles.ProgressBar.base
         ]}
       />

--- a/src/packages/solid/types/interfaces.d.ts
+++ b/src/packages/solid/types/interfaces.d.ts
@@ -30,4 +30,6 @@ export interface UIComponentProps extends IntrinsicNodeProps {
    * sets the component's color palette
    */
   tone?: Tone;
+
+  toneStyles?: any; // TODO add type
 }

--- a/src/packages/solid/utils/createComponentWithTone.tsx
+++ b/src/packages/solid/utils/createComponentWithTone.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Component } from 'solid-js';
+import type { Tone } from '../types/types.js';
+import objectFromEntries from './objectFromEntries.js';
+
+const getToneFromStyles = <ComponentStyle,>(tone: Tone, styles: ComponentStyle) =>
+  objectFromEntries(
+    Object.entries(styles).map(([element, styleObject]) => [element, styleObject.tones?.[tone]])
+  );
+
+const createComponentWithTone = <Props, ComponentStyle>(
+  Component: Component<Props>,
+  tone: Tone,
+  styles: ComponentStyle
+) => {
+  const tonedStyles = getToneFromStyles<ComponentStyle>(tone, styles);
+
+  const TonedComponent = (props: Props) => <Component {...props} toneStyles={tonedStyles} />;
+  return TonedComponent;
+};
+
+export default createComponentWithTone;


### PR DESCRIPTION
## Description

First pass at making tones more static. I'm not sure if this actually achieves what we'd discussed @chiefcll, however I can't pass the styles through props since the sub-node toneStyles need to be explicitly mapped to the right node. 

This PR adds a Higher Order Component(sorta? we're not exactly wrapping the component so it might be a different pattern) to add tones to a component. Instead of using the inline prop like we currently are, `createComponentWithTone` parses out the tone styles of a given component and passes them to the component with a special prop. the component uses the styles from this prop(if present) to add tones to the given component.

This draft is meant to be a collaborative effort - I'm not sure if this is the right path forward, or if we even gain anything of real substance from this approach
