### PR TITLE
fix(Solid): fix icon types imports path

### DIFF
--- a/src/packages/solid/components/Checkbox/Checkbox.styles.ts
+++ b/src/packages/solid/components/Checkbox/Checkbox.styles.ts
@@ -20,7 +20,7 @@ import theme from 'theme';
 import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
-import type { IconConfig, IconStyles } from '../Icon/Icon.styles.js';
+import type { IconConfig, IconStyles } from '../Icon/Icon.types.js';
 
 export interface CheckboxStyles {
   tone: Tone;

--- a/src/packages/solid/components/Metadata/Rating.styles.ts
+++ b/src/packages/solid/components/Metadata/Rating.styles.ts
@@ -20,8 +20,7 @@ import theme from 'theme';
 import type { Tone } from '../../types/types.js';
 import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet } from '../../types/types.js';
 import { makeComponentStyles } from '../../utils/index.js';
-import type { IconStyles } from '../Icon/Icon.styles.js';
-import type { IconConfig } from '../Icon/Icon.styles.js';
+import type { IconStyles, IconConfig } from '../Icon/Icon.types.js';
 
 export interface RatingStyles {
   tone: Tone;

--- a/src/packages/solid/components/Metadata/Rating.tsx
+++ b/src/packages/solid/components/Metadata/Rating.tsx
@@ -19,7 +19,7 @@ import { Text, Show, View, type TextProps } from '@lightningjs/solid';
 import type { UIComponentProps } from '../../types/interfaces.js';
 import styles from './Rating.styles.js';
 import Icon from '../Icon/Icon.jsx';
-import type { IconProps } from '../Icon/Icon.jsx';
+import type { IconProps } from '../Icon/Icon.types.jsx';
 
 export interface RatingProps extends UIComponentProps {
   /**


### PR DESCRIPTION
## Description

updates the path of icon types imports to be from Icon.types

## Changes

## Testing

Make sure checkbox and ratings render correctly
