### PR TITLE
fix(Solid): removes spread from styles props in Radio

### DIFF
--- a/src/packages/solid/components/Radio/Radio.stories.tsx
+++ b/src/packages/solid/components/Radio/Radio.stories.tsx
@@ -49,8 +49,6 @@ export default meta;
 export const Basic = {
   render: args => <Radio {...args} />,
   args: {
-    checked: true,
-    states: 'focus',
-    tone: 'neutral'
+    checked: true
   }
 };

--- a/src/packages/solid/components/Radio/Radio.styles.ts
+++ b/src/packages/solid/components/Radio/Radio.styles.ts
@@ -40,7 +40,9 @@ export type RadioStyleProperties = {
   strokeRadius?: NodeStyles['borderRadius'];
 };
 
-type RadioConfig = ComponentStyleConfig<RadioStyleProperties>;
+export type RadioModes = 'checked' | 'focus' | 'disabled';
+
+type RadioConfig = ComponentStyleConfig<RadioStyleProperties, RadioModes>;
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
 const { Radio: { defaultTone, ...themeStyles } = { themeStyles: {} } } = theme?.componentConfig;
@@ -79,6 +81,7 @@ const container: RadioConfig = {
       }
     }
   },
+  modeKeys: ['focus', 'disabled', 'checked'],
   themeStyles
 };
 

--- a/src/packages/solid/components/Radio/Radio.tsx
+++ b/src/packages/solid/components/Radio/Radio.tsx
@@ -41,16 +41,16 @@ const Radio: Component<RadioProps> = props => {
   return (
     <View
       {...props}
+      // @ts-expect-error TODO type needs to be fixed in framework
       style={[
-        /* @ts-expect-error next-line deconstructed style object should work here */
-        ...props.style, //
+        props.style, //
         styles.Container.tones?.[props.tone ?? styles.tone],
         styles.Container.base
       ]}
       states={{ checked: props.checked }}
       children={
         props.checked
-          ? props.children || (
+          ? props.children ?? (
               <View
                 style={[styles.Knob.tones?.[props.tone ?? styles.tone], styles.Knob.base]}
                 color={knobColor()}


### PR DESCRIPTION
## Description

-fixes checked types and allows radio to render 

## Changes
- removes spread of styles props causing the component to fail to render
- adds modeKeys to Radio


## Testing

- check to see the radio renders as it should
