### PR TITLE
fix: rating and metadata basic display properly

### DIFF
--- a/src/packages/solid/components/Metadata/Details.tsx
+++ b/src/packages/solid/components/Metadata/Details.tsx
@@ -85,10 +85,6 @@ const Details: Component<DetailsProps> = (props: DetailsProps) => {
         {(rating: RatingProps, idx: Accessor<number>) => (
           <Rating
             {...rating}
-            style={[
-              styles.Text.tones[props.tone || styles.tone], //
-              styles.Text.base
-            ]}
             forwardStates
             marginRight={
               props.ratings?.length && idx() === props.ratings.length - 1

--- a/src/packages/solid/components/Metadata/Metadata.stories.tsx
+++ b/src/packages/solid/components/Metadata/Metadata.stories.tsx
@@ -51,15 +51,16 @@ export const Basic = {
     maxLines: 3,
     details: {
       title: 'Support text',
+      height: 35,
       badges: [{ title: 'TV-14' }, { title: 'HD' }, { title: 'CC' }],
       ratings: [
         {
           src: lightning,
-          title: 76
+          title: '76'
         },
         {
           src: lightning,
-          title: 96
+          title: '96'
         }
       ]
     },

--- a/src/packages/solid/components/Metadata/Rating.styles.ts
+++ b/src/packages/solid/components/Metadata/Rating.styles.ts
@@ -34,6 +34,7 @@ type RatingStyleProperties = {
   textAlign?: TextStyles['textAlign'];
   textColor?: TextStyles['color'];
   itemSpacing?: NodeStyles['itemSpacing'];
+  alignItems?: NodeStyles['alignItems'];
 };
 
 type RatingConfig = ComponentStyleConfig<RatingStyleProperties>;
@@ -48,9 +49,10 @@ const container: RatingConfig = {
   },
   base: {
     display: 'flex',
-    flexDirection: 'column',
+    flexDirection: 'row',
     justifyContent: 'flexStart',
-    itemSpacing: theme.spacer.sm
+    itemSpacing: theme.spacer.sm,
+    alignItems: 'center'
   },
   themeStyles
 };
@@ -62,6 +64,25 @@ const text: RatingConfig = {
   base: {
     color: theme.color.textNeutral,
     ...theme.typography.body2
+  },
+  tones: {
+    neutral: {
+      disabled: {
+        color: theme.color.textNeutralDisabled
+      }
+    },
+    inverse: {
+      color: theme.color.textInverse,
+      disabled: {
+        color: theme.color.textNeutralDisabled
+      }
+    },
+    brand: {
+      color: theme.color.textNeutral,
+      disabled: {
+        color: theme.color.textNeutralDisabled
+      }
+    }
   },
   themeStyles
 };

--- a/src/packages/solid/components/Metadata/Rating.tsx
+++ b/src/packages/solid/components/Metadata/Rating.tsx
@@ -47,7 +47,6 @@ const Rating: Component<RatingProps> = (props: RatingProps) => {
   const formattedTitle = createMemo(() => formatTitle(props.title));
   return (
     <View
-      {...props}
       forwardStates
       // @ts-expect-error TODO type needs to be fixed in framework
       style={[


### PR DESCRIPTION
## Description

The metadata basic was misaligned due to style issues in the rating component. 

**Before**
<img width="955" alt="Screenshot 2024-05-16 at 10 10 26 AM" src="https://github.com/lightning-js/ui-components/assets/32280146/9c0799d8-bf0e-4140-9ab6-73e99ce41b36">

**After**
<img width="869" alt="Screenshot 2024-05-20 at 10 51 36 AM" src="https://github.com/lightning-js/ui-components/assets/32280146/f9fb5ad3-ae43-49ff-bc33-a7863c488077">

## Changes

- Removed props spread in rating view
- Tones added to rating styles
- Rating aligned in with detail and rating flex direction updated

## Testing

Checkout to branch, observe metadata basic is properly sized and aligned.
