### PR TITLE
chore: update templates to match latest patterns, wrap ComponentName placeholder in <>

### DIFF
--- a/src/packages/solid/templates/stories.template
+++ b/src/packages/solid/templates/stories.template
@@ -15,22 +15,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component } from 'solid-js';
-import { View } from '@lightningjs/solid';
-import type { <ComponentName>Props } from './<ComponentName>.types.js';
+import <ComponentName> from './<ComponentName>.jsx';
 import styles from './<ComponentName>.styles.js';
 
-const <ComponentName>: Component<<ComponentName>Props> = props => {
-  return (
-    <View
-      {...props}
-      style={[
-        props.style, //
-        styles.Container.tones?.[props.tone ?? styles.tone],
-        styles.Container.base
-      ]}
-    />
-  );
+const meta = {
+  title: 'Components/<ComponentName>',
+  component: <ComponentName>,
+  tags: ['autodocs'],
+  argTypes: {
+    // add any controllable props here
+    tone: { // remove if the component doesn't support tones
+      control: { type: 'radio' },
+      options: ['neutral', 'inverse', 'brand'],
+      description: 'Sets the tone for the component',
+      table: {
+        defaultValue: { summary: 'neutral' }
+      }
+    }
+  }
 };
 
-export default <ComponentName>;
+export default meta;
+
+export const Basic = {
+  args: {}
+};

--- a/src/packages/solid/templates/styles.template
+++ b/src/packages/solid/templates/styles.template
@@ -27,24 +27,24 @@ import { makeComponentStyles } from '../../utils/index.js';
 
 // includes the tone and all returned style sets, usually one per element
 // NodeStyleSet(and TextStyleSet) is a generic that takes an object<T> and returns `NodeStyles & T`
-export interface NewComponentStyles {
+export interface <ComponentName>Styles {
   tone: Tone;
   // ex. Container: NodeStyleSet;
 }
 
 // list of all values expected in a componentConfig, and their type
 // usually these map to a NodeStyle or TextStyle type
-type NewComponentStyleProperties = Partial<{
+type <ComponentName>StyleProperties = Partial<{
   // ex. backgroundColor: NodeStyles['color'];
 }>;
 
-type NewComponentConfig = ComponentStyleConfig<NewComponentStyleProperties>;
+type <ComponentName>Config = ComponentStyleConfig<<ComponentName>StyleProperties>;
 
 // replace Component with the component name, this line imports overrides from the theme's componentConfig if they exist
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
 const { Component: { defaultTone, ...themeStyles } = { themeStyles: {} } } = theme?.componentConfig;
 
-const container: NewComponentConfig = {
+const container: <ComponentName>Config = {
   themeKeys: {
     // key/value pairs mapping this element's property to the incoming componentConfig value
     // the values here should be listed in the ComponentStyleProperties type
@@ -87,7 +87,7 @@ const container: NewComponentConfig = {
 // ex. const Container = makeComponentStyles<ComponentStyle['Container']>(container);
 
 // the object returned to the component
-const styles: NewComponentStyle = {
+const styles: <ComponentName>Style = {
   tone: defaultTone || 'neutral'
   // ex. Container
 };

--- a/src/packages/solid/templates/types.template
+++ b/src/packages/solid/templates/types.template
@@ -15,22 +15,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component } from 'solid-js';
-import { View } from '@lightningjs/solid';
-import type { <ComponentName>Props } from './<ComponentName>.types.js';
-import styles from './<ComponentName>.styles.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
-const <ComponentName>: Component<<ComponentName>Props> = props => {
-  return (
-    <View
-      {...props}
-      style={[
-        props.style, //
-        styles.Container.tones?.[props.tone ?? styles.tone],
-        styles.Container.base
-      ]}
-    />
-  );
-};
+interface <ComponentName>Props extends UIComponentProps {
+  // component specific props  
+}
 
-export default <ComponentName>;
+// only necessary if the component should follow the Container pattern
+interface <ComponentName>ContainerProps extends UIComponentProps {
+  // container specific props
+}


### PR DESCRIPTION
## Changes

- update templates to match new patterns
- add `types` file template
- make ComponentName easier to find and replace by wrapping it in <>
