### PR TITLE
fix(Solid): update Metadata details view

### DIFF
--- a/src/packages/solid/components/Metadata/Metadata.tsx
+++ b/src/packages/solid/components/Metadata/Metadata.tsx
@@ -71,7 +71,9 @@ const Metadata: Component<MetadataProps> = (props: MetadataProps) => {
           {props.description}
         </Text>
       </Show>
-      <Details width={props.width} {...props.details} tone={props.tone ?? styles.tone} />
+      <Show when={props.details}>
+        <Details width={props.width} {...props.details} tone={props.tone ?? styles.tone} />
+      </Show>
     </View>
   );
 };


### PR DESCRIPTION
## Description

The Details component within Metadata did not have a conditional Show tag applied causing Metadata to hold space for the Details even when it's not in use. This held space was causing extra space in components where Metadata is used and Details is not needed. See **before** and **after** photos of the tile using Metadata below. Observe the extra blank space held for the nonexistent Details in the **before** photo. 

![Screenshot 2024-05-28 at 10 34 25 AM](https://github.com/lightning-js/ui-components/assets/32280146/0aa55c6d-82a9-41ea-9fab-b75a7bb5ddb6)

![Screenshot 2024-05-28 at 10 34 06 AM](https://github.com/lightning-js/ui-components/assets/32280146/f72aaa9a-c4b4-4bdf-b0a1-53590799875d)


## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
